### PR TITLE
feat(proposal): add VERSION_4_8_2_PQ1 and reassign PQC proposal codes

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
@@ -1060,8 +1060,8 @@ public class ProposalUtil {
     ALLOW_TVM_OSAKA(96), // 0, 1
     ALLOW_HARDEN_RESOURCE_CALCULATION(97), // 0, 1
     ALLOW_HARDEN_EXCHANGE_CALCULATION(98), // 0, 1
-    ALLOW_FN_DSA_512(99), // 0, 1
-    ALLOW_ML_DSA_44(100); // 0, 1
+    ALLOW_FN_DSA_512(1000), // 0, 1
+    ALLOW_ML_DSA_44(1001); // 0, 1
 
     private long code;
 

--- a/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/ProposalUtil.java
@@ -944,7 +944,7 @@ public class ProposalUtil {
         break;
       }
       case ALLOW_FN_DSA_512: {
-        if (!forkController.pass(ForkBlockVersionEnum.VERSION_4_8_2)) {
+        if (!forkController.pass(ForkBlockVersionEnum.VERSION_4_8_2_PQ1)) {
           throw new ContractValidateException("Bad chain parameter id [ALLOW_FN_DSA_512]");
         }
         if (value != 0 && value != 1) {
@@ -958,7 +958,7 @@ public class ProposalUtil {
         break;
       }
       case ALLOW_ML_DSA_44: {
-        if (!forkController.pass(ForkBlockVersionEnum.VERSION_4_8_2)) {
+        if (!forkController.pass(ForkBlockVersionEnum.VERSION_4_8_2_PQ1)) {
           throw new ContractValidateException("Bad chain parameter id [ALLOW_ML_DSA_44]");
         }
         if (value != 0 && value != 1) {

--- a/common/src/main/java/org/tron/core/config/Parameter.java
+++ b/common/src/main/java/org/tron/core/config/Parameter.java
@@ -30,7 +30,8 @@ public class Parameter {
     VERSION_4_8_1(33, 1596780000000L, 80),//The hard fork activation order on Nile is 4.8.0 → 4.8.1 → 4.8.0.1
     VERSION_4_8_0_1(34, 1596780000000L, 70),//The hard fork activation order on Nile is 4.8.0 → 4.8.1 → 4.8.0.1
     VERSION_4_8_1_1(35, 1596780000000L, 70),
-    VERSION_4_8_2(36, 1596780000000L, 80);
+    VERSION_4_8_2(36, 1596780000000L, 80),
+    VERSION_4_8_2_PQ1(37, 1596780000000L, 80);
     // if add a version, modify BLOCK_VERSION simultaneously
 
     @Getter
@@ -79,7 +80,7 @@ public class Parameter {
     public static final int SINGLE_REPEAT = 1;
     public static final int BLOCK_FILLED_SLOTS_NUMBER = 128;
     public static final int MAX_FROZEN_NUMBER = 1;
-    public static final int BLOCK_VERSION = 36;
+    public static final int BLOCK_VERSION = 37;
     public static final long FROZEN_PERIOD = 86_400_000L;
     public static final long DELEGATE_PERIOD = 3 * 86_400_000L;
     public static final long TRX_PRECISION = 1000_000L;

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -898,8 +898,8 @@ committee = {
   dynamicEnergyThreshold = 0          # getDynamicEnergyThreshold, #73: usage threshold for dynamic energy
   dynamicEnergyIncreaseFactor = 0     # getDynamicEnergyIncreaseFactor, #74: dynamic energy increase factor
   dynamicEnergyMaxFactor = 0          # getDynamicEnergyMaxFactor, #75: maximum dynamic energy factor
-  allowFnDsa512 = 0                   # getAllowFnDsa512, #99: enable FN-DSA-512 (Falcon) post-quantum signatures
-  allowMlDsa44 = 0                    # getAllowMlDsa44, #100: enable ML-DSA-44 (Dilithium) post-quantum signatures
+  allowFnDsa512 = 0                   # getAllowFnDsa512, #1000: enable FN-DSA-512 (Falcon) post-quantum signatures
+  allowMlDsa44 = 0                    # getAllowMlDsa44, #1001: enable ML-DSA-44 (Dilithium) post-quantum signatures
 }
 
 # Event subscription settings.

--- a/framework/src/main/java/org/tron/program/Version.java
+++ b/framework/src/main/java/org/tron/program/Version.java
@@ -4,7 +4,7 @@ public class Version {
 
   public static final String VERSION_NAME = "GreatVoyage-v4.8.1-6-g52d7d9d23e";
   public static final String VERSION_CODE = "18643";
-  private static final String VERSION = "4.8.2";
+  private static final String VERSION = "4.8.2.PQ1";
 
   public static String getVersion() {
     return VERSION;

--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -816,12 +816,11 @@ public class ProposalUtilTest extends BaseTest {
     long maintenanceTimeInterval = forkUtils.getManager().getDynamicPropertiesStore()
         .getMaintenanceTimeInterval();
     long hardForkTime =
-        ((ForkBlockVersionEnum.VERSION_4_8_2.getHardForkTime() - 1) / maintenanceTimeInterval + 1)
+        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval + 1)
             * maintenanceTimeInterval;
     forkUtils.getManager().getDynamicPropertiesStore()
         .saveLatestBlockHeaderTimestamp(hardForkTime - 1);
 
-    // 1) before fork 4.8.2 -> rejected
     ContractValidateException thrown = assertThrows(ContractValidateException.class, proposeOne);
     assertEquals("Bad chain parameter id [ALLOW_FN_DSA_512]", thrown.getMessage());
 
@@ -829,7 +828,7 @@ public class ProposalUtilTest extends BaseTest {
         .saveLatestBlockHeaderTimestamp(hardForkTime + 1);
     Arrays.fill(stats, (byte) 1);
     forkUtils.getManager().getDynamicPropertiesStore()
-        .statsByVersion(ForkBlockVersionEnum.VERSION_4_8_2.getValue(), stats);
+        .statsByVersion(ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getValue(), stats);
 
     // 2) value not in {0, 1} -> rejected
     thrown = assertThrows(ContractValidateException.class, proposeTwo);
@@ -879,7 +878,7 @@ public class ProposalUtilTest extends BaseTest {
     long maintenanceTimeInterval = forkUtils.getManager().getDynamicPropertiesStore()
         .getMaintenanceTimeInterval();
     long hardForkTime =
-        ((ForkBlockVersionEnum.VERSION_4_8_2.getHardForkTime() - 1) / maintenanceTimeInterval + 1)
+        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval + 1)
             * maintenanceTimeInterval;
     forkUtils.getManager().getDynamicPropertiesStore()
         .saveLatestBlockHeaderTimestamp(hardForkTime - 1);
@@ -891,7 +890,7 @@ public class ProposalUtilTest extends BaseTest {
         .saveLatestBlockHeaderTimestamp(hardForkTime + 1);
     Arrays.fill(stats, (byte) 1);
     forkUtils.getManager().getDynamicPropertiesStore()
-        .statsByVersion(ForkBlockVersionEnum.VERSION_4_8_2.getValue(), stats);
+        .statsByVersion(ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getValue(), stats);
 
     thrown = assertThrows(ContractValidateException.class, proposeTwo);
     assertEquals("This value[ALLOW_ML_DSA_44] is only allowed to be 0 or 1", thrown.getMessage());

--- a/framework/src/test/java/org/tron/core/services/ProposalServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/ProposalServiceTest.java
@@ -57,7 +57,7 @@ public class ProposalServiceTest extends BaseTest {
     boolean result = ProposalService.process(dbManager, proposalCapsule);
     Assert.assertTrue(result);
     //
-    proposal = Proposal.newBuilder().putParameters(1000, 1).build();
+    proposal = Proposal.newBuilder().putParameters(9999, 1).build();
     proposalCapsule = new ProposalCapsule(proposal);
     result = ProposalService.process(dbManager, proposalCapsule);
     Assert.assertFalse(result);


### PR DESCRIPTION
**What does this PR do?**

1. Updates proposal parameter codes for `ALLOW_FN_DSA_512` and `ALLOW_ML_DSA_44` from 99/100 to 1000/1001 in `ProposalUtil.java`
2. Adds a new hard-fork version `VERSION_4_8_2_PQ1` (block version 37) and gates both PQC proposals on it instead of `VERSION_4_8_2`
3. Bumps node version string to `4.8.2.PQ1` in `Version.java`
4. Syncs the proposal code comments in `reference.conf` and fixes the invalid-code assertion in `ProposalServiceTest` that collided with the new codes

**Why are these changes required?**

The original codes 99 and 100 conflicted with planned proposals on the 4.8.x series. Codes 1000/1001 are reserved for post-quantum proposals to avoid collision. Introducing `VERSION_4_8_2_PQ1` decouples the PQC governance proposals from the 4.8.2 hard fork, allowing them to be activated independently.

**This PR has been tested by:**
- Unit Tests

**Follow up**

**Extra details**
