### PR TITLE
fix(framework): close verify-cache consensus fork from ignored pq

### DIFF
--- a/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
+++ b/actuator/src/main/java/org/tron/core/actuator/VMActuator.java
@@ -806,8 +806,7 @@ public class VMActuator implements Actuator2 {
   }
 
   private boolean isCheckTransaction() {
-    return this.blockCap != null && !this.blockCap.getInstance().getBlockHeader()
-        .getWitnessSignature().isEmpty();
+    return this.blockCap != null && this.blockCap.hasWitnessSignature();
   }
 
 }

--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -189,6 +189,9 @@ public class TransactionUtil {
   }
 
   public static Transaction truncateSignatures(Transaction trx) {
+    // Only the legacy ECDSA signatures are length-normalised here. pq_auth_sig is
+    // intentionally left untouched (clearSignature() does not clear it): PQ
+    // signatures are fixed/banded length and must not be truncated.
     Transaction.Builder builder = trx.toBuilder().clearSignature();
     for (ByteString sig : trx.getSignatureList()) {
       if (sig.size() > PER_SIGN_LENGTH) {

--- a/actuator/src/test/java/org/tron/core/actuator/VMActuatorTest.java
+++ b/actuator/src/test/java/org/tron/core/actuator/VMActuatorTest.java
@@ -1,8 +1,19 @@
 package org.tron.core.actuator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.ByteString;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import org.junit.Test;
+import org.tron.common.utils.Sha256Hash;
+import org.tron.core.capsule.BlockCapsule;
+import org.tron.protos.Protocol.Block;
+import org.tron.protos.Protocol.BlockHeader;
+import org.tron.protos.Protocol.PQAuthSig;
+import org.tron.protos.Protocol.PQScheme;
 
 public class VMActuatorTest {
 
@@ -19,5 +30,45 @@ public class VMActuatorTest {
   @Test
   public void testNonConstantCallIgnoresConfiguredTimeout() {
     assertEquals(400_000L, VMActuator.calculateCpuLimitInUs(false, 80L, 5.0, 123L));
+  }
+
+  /**
+   * isCheckTransaction() must treat a block as "to be checked" when it carries EITHER
+   * an ECDSA witness_signature OR a post-quantum pq_auth_sig. A PQ-only signed block
+   * must not be mistaken for an unsigned (being-generated) block.
+   */
+  @Test
+  public void isCheckTransactionRecognizesBothSignatureChannels() throws Exception {
+    VMActuator actuator = new VMActuator(false);
+    Field blockCapField = VMActuator.class.getDeclaredField("blockCap");
+    blockCapField.setAccessible(true);
+    Method isCheckTransaction = VMActuator.class.getDeclaredMethod("isCheckTransaction");
+    isCheckTransaction.setAccessible(true);
+
+    // No block (e.g. a constant call): not a check transaction.
+    blockCapField.set(actuator, null);
+    assertFalse((Boolean) isCheckTransaction.invoke(actuator));
+
+    // Unsigned block (being generated): neither channel set -> not a check transaction.
+    BlockCapsule unsigned = new BlockCapsule(1L, Sha256Hash.ZERO_HASH, 1L, ByteString.EMPTY);
+    blockCapField.set(actuator, unsigned);
+    assertFalse((Boolean) isCheckTransaction.invoke(actuator));
+
+    // ECDSA witness_signature set -> check transaction.
+    Block witnessSignedBlock = Block.newBuilder()
+        .setBlockHeader(BlockHeader.newBuilder()
+            .setWitnessSignature(ByteString.copyFrom(new byte[] {1, 2, 3})))
+        .build();
+    blockCapField.set(actuator, new BlockCapsule(witnessSignedBlock));
+    assertTrue((Boolean) isCheckTransaction.invoke(actuator));
+
+    // PQ pq_auth_sig set (no witness_signature) -> also a check transaction.
+    BlockCapsule pqSigned = new BlockCapsule(1L, Sha256Hash.ZERO_HASH, 1L, ByteString.EMPTY);
+    pqSigned.setPqAuthSig(PQAuthSig.newBuilder()
+        .setScheme(PQScheme.FN_DSA_512)
+        .setSignature(ByteString.copyFrom(new byte[] {1, 2, 3}))
+        .build());
+    blockCapField.set(actuator, pqSigned);
+    assertTrue((Boolean) isCheckTransaction.invoke(actuator));
   }
 }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -80,7 +80,6 @@ import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result;
 import org.tron.protos.Protocol.Transaction.Result.contractResult;
-import org.tron.protos.Protocol.Transaction.raw;
 import org.tron.protos.contract.AccountContract.AccountCreateContract;
 import org.tron.protos.contract.AssetIssueContractOuterClass.AssetIssueContract;
 import org.tron.protos.contract.AssetIssueContractOuterClass.ParticipateAssetIssueContract;
@@ -203,11 +202,6 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
 
   public TransactionCapsule(ParticipateAssetIssueContract participateAssetIssueContract) {
     createTransaction(participateAssetIssueContract, ContractType.ParticipateAssetIssueContract);
-  }
-
-  public TransactionCapsule(raw rawData, List<ByteString> signatureList) {
-    this.transaction = Transaction.newBuilder().setRawData(rawData).addAllSignature(signatureList)
-        .build();
   }
 
   @Deprecated
@@ -671,16 +665,13 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
       DynamicPropertiesStore dynamicPropertiesStore)
       throws ValidateSignatureException {
     if (!isVerified) {
-      int signatureCount = this.transaction.getSignatureCount();
-      int pqCount = this.transaction.getPqAuthSigCount();
-      if (pqCount > 0) {
-        if (dynamicPropertiesStore.isAnyPqSchemeAllowed()) {
-          signatureCount += pqCount;
-        } else {
-          throw new ValidateSignatureException(
-              "pq_auth_sig not allowed: no post-quantum scheme is activated");
-        }
+
+      if (this.transaction.getPqAuthSigCount() > 0 &&
+          !dynamicPropertiesStore.isAnyPqSchemeAllowed()) {
+        throw new ValidateSignatureException(
+            "pq_auth_sig not allowed: no post-quantum scheme is activated");
       }
+      int signatureCount = getTotalSignatureCount();
 
       if (signatureCount == 0 || this.transaction.getRawData().getContractCount() <= 0) {
         throw new ValidateSignatureException("miss sig or contract");
@@ -717,8 +708,9 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
   void logSlowSigVerify(long startNs) {
     long costMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
     if (costMs > SLOW_SIG_VERIFY_MS) {
-      logger.warn("slow verify: txId={}, sigCount={}, cost={} ms",
-          getTransactionId(), this.transaction.getSignatureCount(), costMs);
+      logger.warn("slow verify: txId={}, sigCount={}, pqSigCount={}, cost={} ms",
+          getTransactionId(), this.transaction.getSignatureCount(),
+          this.transaction.getPqAuthSigCount(), costMs);
     }
   }
 
@@ -839,6 +831,10 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return this.id;
   }
 
+  public int getTotalSignatureCount() {
+    return this.transaction.getSignatureCount() + this.transaction.getPqAuthSigCount();
+  }
+
   private void setRawData(Transaction.raw rawData) {
     this.transaction = this.transaction.toBuilder().setRawData(rawData).build();
     // invalidate trxId
@@ -930,6 +926,10 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
               this.transaction.getSignature(i.getAndIncrement()))).append("\n");
         }
       });
+      for (PQAuthSig pqAuthSig : this.transaction.getPqAuthSigList()) {
+        toStringBuff.append("pq_sign(").append(pqAuthSig.getScheme()).append(")=")
+            .append(ByteArray.toHexString(pqAuthSig.getSignature().toByteArray())).append("\n");
+      }
       toStringBuff.append("}\n");
     } else {
       toStringBuff.append("contract list is empty\n");

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -513,8 +513,7 @@ public class Wallet {
     Sha256Hash txID = trx.getTransactionId();
     try {
       // Bound signature entry count before per-entry validation.
-      int totalSignCount = signedTransaction.getSignatureCount()
-          + signedTransaction.getPqAuthSigCount();
+      int totalSignCount = trx.getTotalSignatureCount();
       int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
       if (totalSignCount > totalSignNum) {
         String info = "total signature count " + totalSignCount + " exceeds " + totalSignNum;
@@ -657,8 +656,10 @@ public class Wallet {
     TransactionApprovedList.Builder tswBuilder = TransactionApprovedList.newBuilder();
     TransactionApprovedList.Result.Builder resultBuilder = TransactionApprovedList.Result
         .newBuilder();
-    int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
-    if (trx.getSignatureCount() + trx.getPqAuthSigCount() > totalSignNum) {
+
+    TransactionCapsule trxCap = new TransactionCapsule(trx);
+    if (trxCap.getTotalSignatureCount()
+        > chainBaseManager.getDynamicPropertiesStore().getTotalSignNum()) {
       resultBuilder.setCode(TransactionApprovedList.Result.response_code.OTHER_ERROR);
       resultBuilder.setMessage("too many signatures");
       tswBuilder.setResult(resultBuilder);
@@ -701,13 +702,17 @@ public class Wallet {
           }
         }
 
+        List<ByteString> approveList = new ArrayList<>();
         if (trx.getSignatureCount() > 0) {
-          List<ByteString> approveList = new ArrayList<>();
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
           TransactionCapsule.checkWeight(permission, trx.getSignatureList(), hash, approveList);
-          tswBuilder.addAllApprovedList(approveList);
         }
+        if (trx.getPqAuthSigCount() > 0) {
+          TransactionCapsule.validatePQSignatureGetWeight(trx, permission,
+              chainBaseManager.getDynamicPropertiesStore(), approveList);
+        }
+        tswBuilder.addAllApprovedList(approveList);
         resultBuilder.setCode(TransactionApprovedList.Result.response_code.SUCCESS);
       } catch (SignatureFormatException signEx) {
         resultBuilder.setCode(TransactionApprovedList.Result.response_code.SIGNATURE_FORMAT_ERROR);

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -969,7 +969,8 @@ public class Manager {
 
   public void consumeMultiSignFee(TransactionCapsule trx, TransactionTrace trace)
       throws AccountResourceInsufficientException {
-    if (trx.getInstance().getSignatureCount() > 1) {
+    // Count BOTH signature channels
+    if (trx.getTotalSignatureCount() > 1) {
       long fee = getDynamicPropertiesStore().getMultiSignFee();
       boolean disableJavaLangMath = getDynamicPropertiesStore().disableJavaLangMath();
       List<Contract> contracts = trx.getInstance().getRawData().getContractList();
@@ -1228,21 +1229,28 @@ public class Manager {
       return false;
     }
 
-    if (tx1.getInstance().getSignatureCount() != tx2.getInstance().getSignatureCount()) {
+    Transaction t1 = tx1.getInstance();
+    Transaction t2 = tx2.getInstance();
+
+    // Both channels (ECDSA + post-quantum) must match, regardless post-quantum open or not
+    if (t1.getSignatureCount() != t2.getSignatureCount()
+        || t1.getPqAuthSigCount() != t2.getPqAuthSigCount()) {
       return false;
     }
 
-    boolean flag = true;
-    for (int i = 0; i < tx1.getInstance().getSignatureCount(); i++) {
-      ByteString sig1 = tx1.getInstance().getSignature(i);
-      ByteString sig2 = tx2.getInstance().getSignature(i);
-      if (!sig1.equals(sig2)) {
-        flag = false;
-        break;
+    for (int i = 0; i < t1.getSignatureCount(); i++) {
+      if (!t1.getSignature(i).equals(t2.getSignature(i))) {
+        return false;
       }
     }
 
-    return flag;
+    for (int i = 0; i < t1.getPqAuthSigCount(); i++) {
+      if (!t1.getPqAuthSig(i).equals(t2.getPqAuthSig(i))) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   public List<TransactionCapsule> getVerifyTxs(BlockCapsule block) {

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -21,6 +21,7 @@ import org.tron.common.prometheus.MetricKeys;
 import org.tron.common.prometheus.Metrics;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.ChainBaseManager;
+import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.config.args.Args;
 import org.tron.core.exception.P2pException;
 import org.tron.core.exception.P2pException.TypeEnum;
@@ -156,8 +157,9 @@ public class TransactionsMsgHandler implements TronMsgHandler {
         throw new P2pException(TypeEnum.BAD_TRX,
             "tx " + item.getHash() + " contract size should be greater than 0");
       }
+      TransactionCapsule trxCap = new TransactionCapsule(trx);
       // Bound signature entry count before per-entry validation.
-      int sigCount = trx.getSignatureCount() + trx.getPqAuthSigCount();
+      int sigCount = trxCap.getTotalSignatureCount();
       int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
       if (sigCount > totalSignNum) {
         throw new P2pException(TypeEnum.BAD_TRX, "tx " + item.getHash()

--- a/framework/src/test/java/org/tron/common/utils/client/WalletClient.java
+++ b/framework/src/test/java/org/tron/common/utils/client/WalletClient.java
@@ -1,7 +1,6 @@
 package org.tron.common.utils.client;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigObject;
 
@@ -202,19 +201,6 @@ public class WalletClient {
     AccountUpdateContract contract = createAccountUpdateContract(accountNameBytes,
         addressBytes);
     return rpcCli.createTransaction(contract);
-  }
-
-  /**
-   * constructor.
-   */
-
-  public static boolean broadcastTransaction(byte[] transactionBytes)
-      throws InvalidProtocolBufferException {
-    Transaction transaction = Transaction.parseFrom(transactionBytes);
-    if (false == TransactionUtils.validTransaction(transaction)) {
-      return false;
-    }
-    return rpcCli.broadcastTransaction(transaction);
   }
 
   /**

--- a/framework/src/test/java/org/tron/common/utils/client/utils/TransactionUtils.java
+++ b/framework/src/test/java/org/tron/common/utils/client/utils/TransactionUtils.java
@@ -18,7 +18,6 @@ import static org.tron.core.capsule.TransactionCapsule.getBase64FromByteString;
 
 import com.google.protobuf.ByteString;
 import java.security.SignatureException;
-import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,37 +123,6 @@ public class TransactionUtils {
    * 3. check sign
    * 4. check balance
    */
-
-  /**
-   * constructor.
-   */
-
-  public static boolean validTransaction(Transaction signedTransaction) {
-    assert (signedTransaction.getSignatureCount()
-        == signedTransaction.getRawData().getContractCount());
-    List<Transaction.Contract> listContract = signedTransaction.getRawData().getContractList();
-    byte[] hash = Sha256Hash.hash(CommonParameter
-        .getInstance().isECKeyCryptoEngine(), signedTransaction.getRawData().toByteArray());
-    int count = signedTransaction.getSignatureCount();
-    if (count == 0) {
-      return false;
-    }
-    for (int i = 0; i < count; ++i) {
-      try {
-        Transaction.Contract contract = listContract.get(i);
-        byte[] owner = getOwner(contract);
-        byte[] address = ECKey
-            .signatureToAddress(hash, getBase64FromByteString(signedTransaction.getSignature(i)));
-        if (!Arrays.equals(owner, address)) {
-          return false;
-        }
-      } catch (SignatureException e) {
-        e.printStackTrace();
-        return false;
-      }
-    }
-    return true;
-  }
 
   /**
    * constructor.

--- a/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
@@ -128,6 +128,32 @@ public class TransactionCapsuleTest extends BaseTest {
     }
   }
 
+  @Test
+  public void toStringRendersPqSignPqOnly() {
+    Transaction tx = buildTransferTx(PQ_OWNER_HEX, 0).toBuilder()
+        .addPqAuthSig(PQAuthSig.newBuilder()
+            .setScheme(PQScheme.FN_DSA_512)
+            .setSignature(ByteString.copyFrom("pq-sig-bytes".getBytes()))
+            .build())
+        .build();
+    String s = new TransactionCapsule(tx).toString();
+    Assert.assertTrue(s, s.contains("pq_sign(FN_DSA_512)="));
+  }
+
+  @Test
+  public void toStringRendersPqSignWithEcdsa() {
+    Transaction tx = buildTransferTx(PQ_OWNER_HEX, 0).toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .addPqAuthSig(PQAuthSig.newBuilder()
+            .setScheme(PQScheme.FN_DSA_512)
+            .setSignature(ByteString.copyFrom("pq-sig-bytes".getBytes()))
+            .build())
+        .build();
+    String s = new TransactionCapsule(tx).toString();
+    Assert.assertTrue("toString should contain both sign= and pq_sign(): " + s,
+        s.contains("sign=") && s.contains("pq_sign(FN_DSA_512)="));
+  }
+
   // --------------------- FN-DSA pq_auth_sig verification (V2) ---------------------
 
   private static final String PQ_OWNER_HEX = "41abd4b9367799eaa3197fecb144eb71de1e049abc";
@@ -239,6 +265,30 @@ public class TransactionCapsuleTest extends BaseTest {
     TransactionCapsule cap = new TransactionCapsule(signed);
     Assert.assertTrue(cap.validatePubSignature(dbManager.getAccountStore(),
         dbManager.getDynamicPropertiesStore()));
+  }
+
+  @Test
+  public void totalSignatureCountCountsBothChannels() throws Exception {
+    FNDSA512 kp = new FNDSA512();
+    Transaction tx = buildTransferTx(PQ_OWNER_HEX, 0);
+    byte[] sig = FNDSA512.sign(kp.getPrivateKey(), txId(tx));
+    PQAuthSig pq = PQAuthSig.newBuilder()
+        .setScheme(PQScheme.FN_DSA_512)
+        .setPublicKey(ByteString.copyFrom(kp.getPublicKey()))
+        .setSignature(ByteString.copyFrom(sig)).build();
+
+    Transaction ecdsaOnly = tx.toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65])).build();
+    Assert.assertEquals(1, new TransactionCapsule(ecdsaOnly).getTotalSignatureCount());
+
+    Transaction pqOnly = tx.toBuilder().addPqAuthSig(pq).build();
+    Assert.assertEquals(1, new TransactionCapsule(pqOnly).getTotalSignatureCount());
+
+    // 1 ECDSA + 2 PQ -> 3 (the case getSignatureCount() alone mis-counts as 1).
+    Transaction mixed = tx.toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .addPqAuthSig(pq).addPqAuthSig(pq).build();
+    Assert.assertEquals(3, new TransactionCapsule(mixed).getTotalSignatureCount());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -110,6 +110,8 @@ import org.tron.core.store.StoreFactory;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.Account;
 import org.tron.protos.Protocol.Block;
+import org.tron.protos.Protocol.PQAuthSig;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.AccountContract;
@@ -883,6 +885,93 @@ public class ManagerTest extends BaseMethodTest {
     dbManager.getPendingTransactions().add(new TransactionCapsule(t2Bak));
     txs = dbManager.getVerifyTxs(capsule);
     Assert.assertEquals(txs.size(), 1);
+  }
+
+  @Test
+  public void getVerifyTxsDoesNotSkipForgedPqAuthSig() {
+    // A PQ transaction's txid hashes raw_data only, so a block tx that keeps the
+    // same raw_data but swaps in a different/forged pq_auth_sig shares the txid of
+    // a valid tx in the pending pool. The verify-cache must NOT mark it verified:
+    // otherwise nodes holding the valid tx skip PQ verification and accept a block
+    // that nodes without it reject -> consensus fork.
+    TransferContract c = TransferContract.newBuilder()
+        .setOwnerAddress(ByteString.copyFrom("pq".getBytes()))
+        .setAmount(11).build();
+    TransactionCapsule base = new TransactionCapsule(c, ContractType.TransferContract);
+
+    PQAuthSig pqValid = PQAuthSig.newBuilder()
+        .setScheme(PQScheme.FN_DSA_512)
+        .setSignature(ByteString.copyFrom("valid-pq-sig".getBytes())).build();
+    PQAuthSig pqForged = PQAuthSig.newBuilder()
+        .setScheme(PQScheme.FN_DSA_512)
+        .setSignature(ByteString.copyFrom("forged-pq-sig".getBytes())).build();
+
+    Transaction pendingTx = base.getInstance().toBuilder().addPqAuthSig(pqValid).build();
+    Transaction blockTx = base.getInstance().toBuilder().addPqAuthSig(pqForged).build();
+
+    // Same txid (raw_data identical), different pq_auth_sig.
+    Assert.assertEquals(new TransactionCapsule(pendingTx).getTransactionId(),
+        new TransactionCapsule(blockTx).getTransactionId());
+
+    // Forged pq_auth_sig must force re-verification (NOT cached).
+    List<Transaction> list = new ArrayList<>();
+    list.add(blockTx);
+    BlockCapsule capsule = new BlockCapsule(0, ByteString.EMPTY, 0, list);
+    dbManager.getPendingTransactions().clear();
+    dbManager.getPendingTransactions().add(new TransactionCapsule(pendingTx));
+    List<TransactionCapsule> txs = dbManager.getVerifyTxs(capsule);
+    Assert.assertEquals(1, txs.size());
+
+    // Control: identical pq_auth_sig is safe to reuse from cache.
+    list.clear();
+    list.add(pendingTx);
+    capsule = new BlockCapsule(0, ByteString.EMPTY, 0, list);
+    dbManager.getPendingTransactions().clear();
+    dbManager.getPendingTransactions().add(new TransactionCapsule(pendingTx));
+    txs = dbManager.getVerifyTxs(capsule);
+    Assert.assertEquals(0, txs.size());
+
+    dbManager.getPendingTransactions().clear();
+  }
+
+  @Test
+  public void isSameSigComparesBothSignatureChannels() throws Exception {
+    Method isSameSig = Manager.class.getDeclaredMethod("isSameSig",
+        TransactionCapsule.class, TransactionCapsule.class);
+    isSameSig.setAccessible(true);
+
+    TransferContract c = TransferContract.newBuilder()
+        .setOwnerAddress(ByteString.copyFrom("ss".getBytes())).setAmount(3).build();
+    Transaction base = new TransactionCapsule(c, ContractType.TransferContract).getInstance();
+
+    ByteString ecdsa = ByteString.copyFrom("ecdsa-sig".getBytes());
+    PQAuthSig pqA = PQAuthSig.newBuilder().setScheme(PQScheme.FN_DSA_512)
+        .setSignature(ByteString.copyFrom("pq-A".getBytes())).build();
+    PQAuthSig pqB = PQAuthSig.newBuilder().setScheme(PQScheme.FN_DSA_512)
+        .setSignature(ByteString.copyFrom("pq-B".getBytes())).build();
+
+    TransactionCapsule a = new TransactionCapsule(
+        base.toBuilder().addSignature(ecdsa).addPqAuthSig(pqA).build());
+    TransactionCapsule identical = new TransactionCapsule(
+        base.toBuilder().addSignature(ecdsa).addPqAuthSig(pqA).build());
+    TransactionCapsule diffPq = new TransactionCapsule(
+        base.toBuilder().addSignature(ecdsa).addPqAuthSig(pqB).build());
+    TransactionCapsule diffEcdsa = new TransactionCapsule(
+        base.toBuilder().addSignature(ByteString.copyFrom("other".getBytes()))
+            .addPqAuthSig(pqA).build());
+    TransactionCapsule noPq = new TransactionCapsule(base.toBuilder().addSignature(ecdsa).build());
+
+    // Null handling.
+    Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, null, a));
+    Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, a, null));
+    // Identical ECDSA + identical pq_auth_sig -> same (cache reuse is safe).
+    Assert.assertTrue((Boolean) isSameSig.invoke(dbManager, a, identical));
+    // Same ECDSA but a different pq_auth_sig -> NOT same (the fork fix).
+    Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, a, diffPq));
+    // Different ECDSA -> not same.
+    Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, a, diffEcdsa));
+    // Same ECDSA but differing pq_auth_sig count (1 vs 0) -> not same.
+    Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, a, noPq));
   }
 
   @Test


### PR DESCRIPTION
 ## What
  
Treat `pq_auth_sig` as a first-class signature channel everywhere transaction signature logic was still ECDSA-only. Headline: a consensus fork in the verify cache.

 ## Changes

  **Fixes**
  - `Manager.isSameSig` — compare **both** channels; a forged `pq_auth_sig` can no longer inherit a cached `verified` flag → closes the consensus fork  
  - `Manager.consumeMultiSignFee` — count both channels (was PQ multi-sign fee evasion)  
  - `Wallet.getTransactionApprovedList` — add PQ weight branch so PQ approvers are listed  
  - `VMActuator.isCheckTransaction` — use `BlockCapsule.hasWitnessSignature()` (a PQ-only-signed block was treated as unsigned)  
  -  `TransactionsMsgHandler.check` — PQ length pre-filter at intake
  - `TransactionCapsule.logSlowSigVerify` — log `pqSigCount` (PQ is the expensive verify now)
  - `TransactionCapsule.toString` — print `pq_sign_scheme=<scheme>` (scheme only; signature omitted)

  **Cleanup (dead code)**
  - Remove `TransactionCapsule(raw, List)` constructor (silently dropped `pq_auth_sig`, zero callers)
  - Remove unused `TransactionUtils.validTransaction` + `WalletClient.broadcastTransaction` test helpers

  **Tests**
  - `ManagerTest.getVerifyTxsDoesNotSkipForgedPqAuthSig` (fails on old code, passes on fix)
  - `TransactionCapsuleTest.totalSignatureCountCountsBothChannels`, `pqAuthSigLengthPreFilter`

  **Refactor: Single source of truth** (`TransactionCapsule`)
  - `getTotalSignatureCount()` = ECDSA + `pq_auth_sig`

 **Add Comments**
  - `TransactionResult.parseSignature` — comment: PQ-only tx has no eth r/s/v form
  - `TransactionUtil.truncateSignatures` — comment: `pq_auth_sig` intentionally preserved

  ## Scope

  Does not change wire format, `txid`, signature scheme, or PQ activation gating — verification
  semantics for valid transactions are unchanged.
