### PR TITLE
fix(jsonrpc): add column pqAuthSigList to TransactionResult

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
@@ -3,6 +3,7 @@ package org.tron.core.services.jsonrpc.types;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getToAddress;
 import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getTransactionAmount;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -59,6 +60,7 @@ public class TransactionResult {
   private String s;
 
   @Getter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private List<PQAuthSigResult> pqAuthSigList;
 
   @JsonPropertyOrder(alphabetic = true)

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
@@ -5,6 +5,8 @@ import static org.tron.core.services.jsonrpc.JsonRpcApiUtil.getTransactionAmount
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
 import org.tron.common.crypto.Rsv;
@@ -13,6 +15,7 @@ import org.tron.core.Wallet;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.protos.Protocol;
+import org.tron.protos.Protocol.PQAuthSig;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
@@ -55,20 +58,46 @@ public class TransactionResult {
   @Getter
   private String s;
 
-  private void parseSignature(Transaction tx) {
+  @Getter
+  private List<PQAuthSigResult> pqAuthSigList;
 
+  @JsonPropertyOrder(alphabetic = true)
+  @ToString
+  public static class PQAuthSigResult {
+
+    @Getter
+    private final String scheme;
+    @Getter
+    private final String publicKey;
+    @Getter
+    private final String signature;
+
+    public PQAuthSigResult(PQAuthSig pqAuthSig) {
+      this.scheme = pqAuthSig.getScheme().name();
+      this.publicKey = ByteArray.toJsonHex(pqAuthSig.getPublicKey().toByteArray());
+      this.signature = ByteArray.toJsonHex(pqAuthSig.getSignature().toByteArray());
+    }
+  }
+
+  private void parseSignature(Transaction tx) {
     if (tx.getSignatureCount() == 0) {
       v = ByteArray.toJsonHex(new byte[1]);
       r = ByteArray.toJsonHex(new byte[32]);
       s = ByteArray.toJsonHex(new byte[32]);
-      return;
+    } else {
+      ByteString signature = tx.getSignature(0); // r[32] + s[32] + v[1]
+      Rsv rsv = Rsv.fromSignature(signature.toByteArray());
+      r = ByteArray.toJsonHex(rsv.getR());
+      s = ByteArray.toJsonHex(rsv.getS());
+      v = ByteArray.toJsonHex(rsv.getV());
     }
 
-    ByteString signature = tx.getSignature(0); // r[32] + s[32] + v[1]
-    Rsv rsv = Rsv.fromSignature(signature.toByteArray());
-    r = ByteArray.toJsonHex(rsv.getR());
-    s = ByteArray.toJsonHex(rsv.getS());
-    v = ByteArray.toJsonHex(rsv.getV());
+    if (tx.getPqAuthSigCount() > 0) {
+      pqAuthSigList = new ArrayList<>();
+      for (PQAuthSig pqAuthSig : tx.getPqAuthSigList()) {
+        pqAuthSigList.add(new PQAuthSigResult(pqAuthSig));
+      }
+    }
   }
 
   private String parseInput(Transaction tx) {

--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -816,9 +816,8 @@ public class ProposalUtilTest extends BaseTest {
     long maintenanceTimeInterval = forkUtils.getManager().getDynamicPropertiesStore()
         .getMaintenanceTimeInterval();
     long hardForkTime =
-        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval +
-            1)
-            * maintenanceTimeInterval;
+        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval
+            + 1) * maintenanceTimeInterval;
     forkUtils.getManager().getDynamicPropertiesStore()
         .saveLatestBlockHeaderTimestamp(hardForkTime - 1);
 
@@ -879,9 +878,8 @@ public class ProposalUtilTest extends BaseTest {
     long maintenanceTimeInterval = forkUtils.getManager().getDynamicPropertiesStore()
         .getMaintenanceTimeInterval();
     long hardForkTime =
-        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval +
-            1)
-            * maintenanceTimeInterval;
+        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval
+            + 1) * maintenanceTimeInterval;
     forkUtils.getManager().getDynamicPropertiesStore()
         .saveLatestBlockHeaderTimestamp(hardForkTime - 1);
 

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
@@ -79,4 +79,99 @@ public class TransactionResultTest extends BaseTest {
     assertQuantity(transactionResult.getNonce());
   }
 
+  private Protocol.Transaction buildBaseTransaction() {
+    SmartContractOuterClass.TriggerSmartContract.Builder builder =
+        SmartContractOuterClass.TriggerSmartContract.newBuilder()
+            .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS)))
+            .setContractAddress(ByteString.copyFrom(ByteArray.fromHexString(CONTRACT_ADDRESS)));
+    return new TransactionCapsule(builder.build(),
+        Protocol.Transaction.Contract.ContractType.TriggerSmartContract).getInstance();
+  }
+
+  // r[0..32] + s[32..64] + v[64], v stored as revId 0 so parseSignature normalizes it to 27.
+  private byte[] buildSignature() {
+    byte[] sign = new byte[65];
+    for (int i = 0; i < 32; i++) {
+      sign[i] = (byte) (i + 1); // r
+    }
+    for (int i = 32; i < 64; i++) {
+      sign[i] = (byte) (i + 1); // s
+    }
+    sign[64] = 0;
+    return sign;
+  }
+
+  private Protocol.PQAuthSig buildPqAuthSig() {
+    return Protocol.PQAuthSig.newBuilder()
+        .setScheme(Protocol.PQScheme.ML_DSA_44)
+        .setPublicKey(ByteString.copyFrom(new byte[] {1, 2, 3}))
+        .setSignature(ByteString.copyFrom(new byte[] {4, 5, 6}))
+        .build();
+  }
+
+  @Test
+  public void testParseSignatureWithNoSignature() {
+    TransactionResult transactionResult =
+        new TransactionResult(buildBaseTransaction(), wallet);
+    // No ECDSA signature and no PQ signature: v/r/s fall back to zero padding.
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[1]), transactionResult.getV());
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[32]), transactionResult.getR());
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[32]), transactionResult.getS());
+    Assert.assertNull(transactionResult.getPqAuthSigList());
+  }
+
+  @Test
+  public void testParseSignatureWithEcdsaSignatureOnly() {
+    byte[] sign = buildSignature();
+    Protocol.Transaction transaction = buildBaseTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(sign))
+        .build();
+
+    TransactionResult transactionResult = new TransactionResult(transaction, wallet);
+    Assert.assertEquals(ByteArray.toJsonHex(java.util.Arrays.copyOfRange(sign, 0, 32)),
+        transactionResult.getR());
+    Assert.assertEquals(ByteArray.toJsonHex(java.util.Arrays.copyOfRange(sign, 32, 64)),
+        transactionResult.getS());
+    // revId 0 is normalized to 27 (0x1b).
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[] {27}), transactionResult.getV());
+    Assert.assertNull(transactionResult.getPqAuthSigList());
+  }
+
+  @Test
+  public void testParseSignatureWithPqAuthSigOnly() {
+    Protocol.PQAuthSig pqAuthSig = buildPqAuthSig();
+    Protocol.Transaction transaction = buildBaseTransaction().toBuilder()
+        .addPqAuthSig(pqAuthSig)
+        .build();
+
+    TransactionResult transactionResult = new TransactionResult(transaction, wallet);
+    // No ECDSA signature: v/r/s remain unset.
+    Assert.assertNull(transactionResult.getV());
+    Assert.assertNull(transactionResult.getR());
+    Assert.assertNull(transactionResult.getS());
+    Assert.assertNotNull(transactionResult.getPqAuthSigList());
+    Assert.assertEquals(1, transactionResult.getPqAuthSigList().size());
+    Assert.assertEquals(pqAuthSig, transactionResult.getPqAuthSigList().get(0));
+  }
+
+  @Test
+  public void testParseSignatureWithEcdsaAndPqAuthSig() {
+    byte[] sign = buildSignature();
+    Protocol.PQAuthSig pqAuthSig = buildPqAuthSig();
+    Protocol.Transaction transaction = buildBaseTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(sign))
+        .addPqAuthSig(pqAuthSig)
+        .build();
+
+    TransactionResult transactionResult = new TransactionResult(transaction, wallet);
+    Assert.assertEquals(ByteArray.toJsonHex(java.util.Arrays.copyOfRange(sign, 0, 32)),
+        transactionResult.getR());
+    Assert.assertEquals(ByteArray.toJsonHex(java.util.Arrays.copyOfRange(sign, 32, 64)),
+        transactionResult.getS());
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[] {27}), transactionResult.getV());
+    Assert.assertNotNull(transactionResult.getPqAuthSigList());
+    Assert.assertEquals(1, transactionResult.getPqAuthSigList().size());
+    Assert.assertEquals(pqAuthSig, transactionResult.getPqAuthSigList().get(0));
+  }
+
 }

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
@@ -145,13 +145,18 @@ public class TransactionResultTest extends BaseTest {
         .build();
 
     TransactionResult transactionResult = new TransactionResult(transaction, wallet);
-    // No ECDSA signature: v/r/s remain unset.
-    Assert.assertNull(transactionResult.getV());
-    Assert.assertNull(transactionResult.getR());
-    Assert.assertNull(transactionResult.getS());
+    // No ECDSA signature: v/r/s fall back to zero padding.
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[1]), transactionResult.getV());
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[32]), transactionResult.getR());
+    Assert.assertEquals(ByteArray.toJsonHex(new byte[32]), transactionResult.getS());
     Assert.assertNotNull(transactionResult.getPqAuthSigList());
     Assert.assertEquals(1, transactionResult.getPqAuthSigList().size());
-    Assert.assertEquals(pqAuthSig, transactionResult.getPqAuthSigList().get(0));
+    TransactionResult.PQAuthSigResult result = transactionResult.getPqAuthSigList().get(0);
+    Assert.assertEquals(pqAuthSig.getScheme().name(), result.getScheme());
+    Assert.assertEquals(ByteArray.toJsonHex(pqAuthSig.getPublicKey().toByteArray()),
+        result.getPublicKey());
+    Assert.assertEquals(ByteArray.toJsonHex(pqAuthSig.getSignature().toByteArray()),
+        result.getSignature());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/TransactionResultTest.java
@@ -176,7 +176,12 @@ public class TransactionResultTest extends BaseTest {
     Assert.assertEquals(ByteArray.toJsonHex(new byte[] {27}), transactionResult.getV());
     Assert.assertNotNull(transactionResult.getPqAuthSigList());
     Assert.assertEquals(1, transactionResult.getPqAuthSigList().size());
-    Assert.assertEquals(pqAuthSig, transactionResult.getPqAuthSigList().get(0));
+    TransactionResult.PQAuthSigResult result = transactionResult.getPqAuthSigList().get(0);
+    Assert.assertEquals(pqAuthSig.getScheme().name(), result.getScheme());
+    Assert.assertEquals(ByteArray.toJsonHex(pqAuthSig.getPublicKey().toByteArray()),
+        result.getPublicKey());
+    Assert.assertEquals(ByteArray.toJsonHex(pqAuthSig.getSignature().toByteArray()),
+        result.getSignature());
   }
 
 }


### PR DESCRIPTION
**What does this PR do?**

Adds a `pqAuthSigList` field to the JSON-RPC `TransactionResult` so that post-quantum authentication signatures are exposed in responses such as `eth_getTransactionByHash`.

Each entry is mapped from the protobuf `PQAuthSig` into a plain serializable POJO (`PQAuthSigResult`) with string fields:
- `scheme` — PQ scheme name (e.g. `ML_DSA_44`)
- `publicKey` — hex-encoded public key
- `signature` — hex-encoded signature

`parseSignature` is also refactored so ECDSA and PQ signatures are handled independently: a transaction may carry an ECDSA signature, one or more PQ signatures, or both. When no ECDSA signature is present, `v`/`r`/`s` fall back to zero padding only when there is no signature of any kind.

**Why are these changes required?**

Previously `pqAuthSigList` was either missing or held the raw protobuf `PQAuthSig` object. Serializing the raw protobuf type fails because Jackson hits a self-reference cycle through `UnknownFieldSet.defaultInstanceForType`, causing `eth_getTransactionByHash` to return JSON-RPC error `-32001` ("Direct self-reference leading to cycle") for any transaction containing a PQ signature. Mapping to a flat POJO of hex strings produces clean, stable JSON and lets clients read PQ auth signatures over JSON-RPC.

**This PR has been tested by:**
- Unit Tests — added `TransactionResultTest` cases covering: no signature, ECDSA only, PQ-auth-sig only, and ECDSA + PQ combined.
- Manual Testing — verified `eth_getTransactionByHash` returns the `pqAuthSigList` field instead of the `-32001` cycle error.

**Follow up**

N/A

**Extra details**

Also includes a minor checkstyle line-wrapping fix in `ProposalUtilTest`.
