### PR TITLE
fix(api): account for pq signature size in getCanDelegatedMaxSize

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -38,6 +38,7 @@ import org.tron.api.GrpcAPI.Return.response_code;
 import org.tron.api.GrpcAPI.TransactionExtention;
 import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.api.GrpcAPI.TransactionSignWeight.Result;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.math.StrictMathWrapper;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.Sha256Hash;
@@ -47,6 +48,7 @@ import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.exception.PermissionException;
 import org.tron.core.exception.SignatureFormatException;
 import org.tron.core.store.DynamicPropertiesStore;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.Protocol.Permission;
 import org.tron.protos.Protocol.Permission.PermissionType;
 import org.tron.protos.Protocol.Transaction;
@@ -294,6 +296,18 @@ public class TransactionUtil {
   }
 
   public static long estimateConsumeBandWidthSize(DynamicPropertiesStore dps, long balance) {
+    return estimateConsumeBandWidthSize(dps, balance, PQScheme.UNKNOWN_PQ_SCHEME);
+  }
+
+  /**
+   * Estimate the bandwidth a delegate-resource transaction consumes. The base cost
+   * ({@link org.tron.core.config.Parameter.ChainConstant#DELEGATE_COST_BASE_SIZE}) assumes an
+   * ECDSA signature. When {@code pqScheme} is a registered post-quantum scheme, the much larger
+   * PQAuthSig wire size is added on top so the estimate stays an upper bound for PQ accounts;
+   * {@code null} / {@code UNKNOWN_PQ_SCHEME} keeps the ECDSA-sized estimate unchanged.
+   */
+  public static long estimateConsumeBandWidthSize(DynamicPropertiesStore dps, long balance,
+      PQScheme pqScheme) {
     DelegateResourceContract.Builder builder;
     if (dps.supportMaxDelegateLockPeriod()) {
       builder = DelegateResourceContract.newBuilder()
@@ -311,6 +325,11 @@ public class TransactionUtil {
     long builder2Size = builder2.build().getSerializedSize();
     long addSize = max(builderSize - builder2Size, 0L, dps.disableJavaLangMath());
 
-    return DELEGATE_COST_BASE_SIZE + addSize;
+    long pqOverhead = 0L;
+    if (PQSchemeRegistry.contains(pqScheme)) {
+      pqOverhead = PQSchemeRegistry.computePQAuthSigWireSize(pqScheme);
+    }
+
+    return DELEGATE_COST_BASE_SIZE + addSize + pqOverhead;
   }
 }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -228,6 +228,7 @@ import org.tron.protos.Protocol.MarketOrderList;
 import org.tron.protos.Protocol.MarketOrderPairList;
 import org.tron.protos.Protocol.MarketPrice;
 import org.tron.protos.Protocol.MarketPriceList;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.Protocol.Permission;
 import org.tron.protos.Protocol.Permission.PermissionType;
 import org.tron.protos.Protocol.Proposal;
@@ -953,11 +954,18 @@ public class Wallet {
   public GrpcAPI.CanDelegatedMaxSizeResponseMessage getCanDelegatedMaxSize(
           ByteString ownerAddress,
           int resourceType) {
+    return getCanDelegatedMaxSize(ownerAddress, resourceType, PQScheme.UNKNOWN_PQ_SCHEME);
+  }
+
+  public GrpcAPI.CanDelegatedMaxSizeResponseMessage getCanDelegatedMaxSize(
+          ByteString ownerAddress,
+          int resourceType,
+          PQScheme pqScheme) {
     long canDelegatedMaxSize = 0L;
     GrpcAPI.CanDelegatedMaxSizeResponseMessage.Builder builder =
           GrpcAPI.CanDelegatedMaxSizeResponseMessage.newBuilder();
     if (Common.ResourceCode.BANDWIDTH.getNumber() == resourceType) {
-      canDelegatedMaxSize = this.calcCanDelegatedBandWidthMaxSize(ownerAddress);
+      canDelegatedMaxSize = this.calcCanDelegatedBandWidthMaxSize(ownerAddress, pqScheme);
     } else if (Common.ResourceCode.ENERGY.getNumber() == resourceType) {
       canDelegatedMaxSize = this.calcCanDelegatedEnergyMaxSize(ownerAddress);
     }
@@ -992,6 +1000,11 @@ public class Wallet {
 
   public long calcCanDelegatedBandWidthMaxSize(
           ByteString ownerAddress) {
+    return calcCanDelegatedBandWidthMaxSize(ownerAddress, PQScheme.UNKNOWN_PQ_SCHEME);
+  }
+
+  public long calcCanDelegatedBandWidthMaxSize(
+          ByteString ownerAddress, PQScheme pqScheme) {
     AccountStore accountStore = chainBaseManager.getAccountStore();
     DynamicPropertiesStore dynamicStore = chainBaseManager.getDynamicPropertiesStore();
     AccountCapsule ownerCapsule = accountStore.get(ownerAddress.toByteArray());
@@ -1004,7 +1017,7 @@ public class Wallet {
 
     long accountNetUsage = ownerCapsule.getNetUsage();
     accountNetUsage += TransactionUtil.estimateConsumeBandWidthSize(dynamicStore,
-            ownerCapsule.getFrozenV2BalanceForBandwidth());
+            ownerCapsule.getFrozenV2BalanceForBandwidth(), pqScheme);
 
     long netUsage = (long) (accountNetUsage * TRX_PRECISION * ((double)
             (dynamicStore.getTotalNetWeight()) / dynamicStore.getTotalNetLimit()));

--- a/framework/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/framework/src/main/java/org/tron/core/services/RpcApiService.java
@@ -554,7 +554,7 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.CanDelegatedMaxSizeResponseMessage> responseObserver) {
       try {
         responseObserver.onNext(wallet.getCanDelegatedMaxSize(
-                        request.getOwnerAddress(),request.getType()));
+                        request.getOwnerAddress(), request.getType(), request.getPqScheme()));
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
       }
@@ -1943,7 +1943,7 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.CanDelegatedMaxSizeResponseMessage> responseObserver) {
       try {
         responseObserver.onNext(wallet.getCanDelegatedMaxSize(
-                        request.getOwnerAddress(), request.getType()));
+                        request.getOwnerAddress(), request.getType(), request.getPqScheme()));
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
       }

--- a/framework/src/main/java/org/tron/core/services/http/GetCanDelegatedMaxSizeServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetCanDelegatedMaxSizeServlet.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.tron.api.GrpcAPI;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.Wallet;
+import org.tron.protos.Protocol.PQScheme;
 
 @Component
 @Slf4j(topic = "API")
@@ -31,9 +32,10 @@ public class GetCanDelegatedMaxSizeServlet extends RateLimiterServlet {
       if (visible) {
         ownerAddress = Util.getHexAddress(ownerAddress);
       }
+      PQScheme pqScheme = parsePqScheme(request.getParameter("pq_scheme"));
       fillResponse(visible,
               ByteString.copyFrom(ByteArray.fromHexString(ownerAddress)),
-              type, response);
+              type, pqScheme, response);
     } catch (Exception e) {
       Util.processError(e, response);
     }
@@ -48,18 +50,39 @@ public class GetCanDelegatedMaxSizeServlet extends RateLimiterServlet {
       JsonFormat.merge(params.getParams(), build, params.isVisible());
       fillResponse(params.isVisible(),
               build.getOwnerAddress(),
-              build.getType(), response);
+              build.getType(), build.getPqScheme(), response);
     } catch (Exception e) {
       Util.processError(e, response);
     }
   }
 
+  // Accepts either the enum name (e.g. "ML_DSA_44") or its number; null/blank falls back to
+  // UNKNOWN_PQ_SCHEME (ECDSA-sized estimate). A present-but-unrecognized value throws, matching the
+  // POST/JsonFormat path which rejects unknown enum names and numbers.
+  static PQScheme parsePqScheme(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return PQScheme.UNKNOWN_PQ_SCHEME;
+    }
+    String trimmed = value.trim();
+    PQScheme scheme;
+    try {
+      scheme = PQScheme.forNumber(Integer.parseInt(trimmed));
+    } catch (NumberFormatException e) {
+      scheme = PQScheme.valueOf(trimmed);
+    }
+    if (scheme == null) {
+      throw new IllegalArgumentException("invalid pq_scheme: " + trimmed);
+    }
+    return scheme;
+  }
+
   private void fillResponse(boolean visible,
                             ByteString ownerAddress,
                             int resourceType,
+                            PQScheme pqScheme,
                             HttpServletResponse response) throws IOException {
     GrpcAPI.CanDelegatedMaxSizeResponseMessage reply =
-            wallet.getCanDelegatedMaxSize(ownerAddress, resourceType);
+            wallet.getCanDelegatedMaxSize(ownerAddress, resourceType, pqScheme);
     if (reply != null) {
       response.getWriter().println(JsonFormat.printToString(reply, visible));
     } else {

--- a/framework/src/test/java/org/tron/core/WalletTest.java
+++ b/framework/src/test/java/org/tron/core/WalletTest.java
@@ -51,6 +51,7 @@ import org.tron.api.GrpcAPI.ProposalList;
 import org.tron.common.BaseTest;
 import org.tron.common.TestConstants;
 import org.tron.common.crypto.ECKey;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Utils;
@@ -88,6 +89,7 @@ import org.tron.protos.Protocol.Block;
 import org.tron.protos.Protocol.BlockHeader;
 import org.tron.protos.Protocol.BlockHeader.raw;
 import org.tron.protos.Protocol.Exchange;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.Protocol.Proposal;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
@@ -1429,6 +1431,51 @@ public class WalletTest extends BaseTest {
         BANDWIDTH.getNumber());
     Assert.assertEquals(frozenBalance / TRX_PRECISION - 279,
         message.getMaxSize() / TRX_PRECISION);
+    chainBaseManager.getDynamicPropertiesStore().saveMaxDelegateLockPeriod(DELEGATE_PERIOD / 3000);
+  }
+
+  /**
+   * A PQ delegate transaction carries a large PQAuthSig, so it consumes much more bandwidth than an
+   * ECDSA one. When a PQ scheme hint is supplied, getCanDelegatedMaxSize must reserve room for that
+   * PQAuthSig wire size and therefore return a strictly smaller max size, otherwise the queried
+   * amount could not actually be delegated by a PQ account.
+   */
+  @Test
+  public void testGetCanDelegatedMaxSizeBandWidthWithPqScheme() {
+    long frozenBalance = 100_000_000_000L;
+    AccountCapsule ownerCapsule =
+        dbManager.getAccountStore().get(ByteArray.fromHexString(OWNER_ADDRESS));
+    ownerCapsule.addFrozenBalanceForBandwidthV2(frozenBalance);
+    ownerCapsule.setNetUsage(0L);
+    ownerCapsule.setEnergyUsage(0L);
+    dbManager.getDynamicPropertiesStore().saveTotalNetWeight(0L);
+    dbManager.getDynamicPropertiesStore().saveTotalEnergyWeight(0L);
+    dbManager.getDynamicPropertiesStore().addTotalNetWeight(
+        frozenBalance / TRX_PRECISION + 43100000000L);
+    dbManager.getAccountStore().put(ownerCapsule.getAddress().toByteArray(), ownerCapsule);
+
+    ByteString owner = ByteString.copyFrom(ByteArray.fromHexString(OWNER_ADDRESS));
+
+    long ecdsaMax = wallet.getCanDelegatedMaxSize(owner, BANDWIDTH.getNumber()).getMaxSize();
+    // UNKNOWN_PQ_SCHEME must behave exactly like the ECDSA (no-scheme) path.
+    long unknownMax = wallet.getCanDelegatedMaxSize(
+        owner, BANDWIDTH.getNumber(), PQScheme.UNKNOWN_PQ_SCHEME).getMaxSize();
+    Assert.assertEquals(ecdsaMax, unknownMax);
+
+    long fnDsaMax = wallet.getCanDelegatedMaxSize(
+        owner, BANDWIDTH.getNumber(), PQScheme.FN_DSA_512).getMaxSize();
+    long mlDsaMax = wallet.getCanDelegatedMaxSize(
+        owner, BANDWIDTH.getNumber(), PQScheme.ML_DSA_44).getMaxSize();
+
+    // Both PQ schemes reserve extra bandwidth, so they yield a smaller max than ECDSA.
+    Assert.assertTrue(fnDsaMax < ecdsaMax);
+    Assert.assertTrue(mlDsaMax < ecdsaMax);
+    // ML_DSA_44 has a larger PQAuthSig than FN_DSA_512, so it reserves more and delegates less.
+    Assert.assertTrue(
+        PQSchemeRegistry.computePQAuthSigWireSize(PQScheme.ML_DSA_44)
+            > PQSchemeRegistry.computePQAuthSigWireSize(PQScheme.FN_DSA_512));
+    Assert.assertTrue(mlDsaMax < fnDsaMax);
+
     chainBaseManager.getDynamicPropertiesStore().saveMaxDelegateLockPeriod(DELEGATE_PERIOD / 3000);
   }
 

--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -816,9 +816,8 @@ public class ProposalUtilTest extends BaseTest {
     long maintenanceTimeInterval = forkUtils.getManager().getDynamicPropertiesStore()
         .getMaintenanceTimeInterval();
     long hardForkTime =
-        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval +
-            1)
-            * maintenanceTimeInterval;
+        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval
+            + 1) * maintenanceTimeInterval;
     forkUtils.getManager().getDynamicPropertiesStore()
         .saveLatestBlockHeaderTimestamp(hardForkTime - 1);
 
@@ -879,9 +878,8 @@ public class ProposalUtilTest extends BaseTest {
     long maintenanceTimeInterval = forkUtils.getManager().getDynamicPropertiesStore()
         .getMaintenanceTimeInterval();
     long hardForkTime =
-        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval +
-            1)
-            * maintenanceTimeInterval;
+        ((ForkBlockVersionEnum.VERSION_4_8_2_PQ1.getHardForkTime() - 1) / maintenanceTimeInterval
+            + 1) * maintenanceTimeInterval;
     forkUtils.getManager().getDynamicPropertiesStore()
         .saveLatestBlockHeaderTimestamp(hardForkTime - 1);
 

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -29,6 +29,7 @@ import org.tron.common.BaseTest;
 import org.tron.common.TestConstants;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Utils;
 import org.tron.core.ChainBaseManager;
@@ -446,6 +447,28 @@ public class TransactionUtilTest extends BaseTest {
         builder.build().getSerializedSize() - builder2.build().getSerializedSize(), 0L, true);
     long actual = TransactionUtil.estimateConsumeBandWidthSize(dps, balance);
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void estimateConsumeBandWidthSizeWithPqScheme() {
+    DynamicPropertiesStore dps = chainBaseManager.getDynamicPropertiesStore();
+    long balance = 100;
+
+    long ecdsaEstimate = TransactionUtil.estimateConsumeBandWidthSize(dps, balance);
+    // null / UNKNOWN_PQ_SCHEME keeps the ECDSA-sized estimate unchanged.
+    Assert.assertEquals(ecdsaEstimate,
+        TransactionUtil.estimateConsumeBandWidthSize(dps, balance, PQScheme.UNKNOWN_PQ_SCHEME));
+    Assert.assertEquals(ecdsaEstimate,
+        TransactionUtil.estimateConsumeBandWidthSize(dps, balance, null));
+
+    for (PQScheme scheme : new PQScheme[] {PQScheme.FN_DSA_512, PQScheme.ML_DSA_44}) {
+      long pqEstimate = TransactionUtil.estimateConsumeBandWidthSize(dps, balance, scheme);
+      // The PQAuthSig wire size is reserved on top of the ECDSA-sized base.
+      Assert.assertEquals(ecdsaEstimate + PQSchemeRegistry.computePQAuthSigWireSize(scheme),
+          pqEstimate);
+      // A PQAuthSig is far larger than an ECDSA signature, so the reserve grows noticeably.
+      Assert.assertTrue(pqEstimate > ecdsaEstimate);
+    }
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
+++ b/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
@@ -74,6 +74,7 @@ import org.tron.protos.Protocol.Account;
 import org.tron.protos.Protocol.Block;
 import org.tron.protos.Protocol.BlockHeader.raw;
 import org.tron.protos.Protocol.MarketOrderPair;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.contract.AccountContract.AccountCreateContract;
 import org.tron.protos.contract.AccountContract.AccountPermissionUpdateContract;
@@ -376,6 +377,13 @@ public class RpcApiServicesTest {
     assertNotNull(blockingStubFull.getCanDelegatedMaxSize(message));
     assertNotNull(blockingStubSolidity.getCanDelegatedMaxSize(message));
     assertNotNull(blockingStubPBFT.getCanDelegatedMaxSize(message));
+
+    // The optional pq_scheme must flow through full / solidity / pbft without error.
+    CanDelegatedMaxSizeRequestMessage pqMessage = CanDelegatedMaxSizeRequestMessage.newBuilder()
+        .setType(0).setOwnerAddress(ownerAddress).setPqScheme(PQScheme.ML_DSA_44).build();
+    assertNotNull(blockingStubFull.getCanDelegatedMaxSize(pqMessage));
+    assertNotNull(blockingStubSolidity.getCanDelegatedMaxSize(pqMessage));
+    assertNotNull(blockingStubPBFT.getCanDelegatedMaxSize(pqMessage));
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/services/http/GetCanDelegatedMaxSizeServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/GetCanDelegatedMaxSizeServletTest.java
@@ -1,0 +1,57 @@
+package org.tron.core.services.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.tron.protos.Protocol.PQScheme;
+
+public class GetCanDelegatedMaxSizeServletTest {
+
+  @Test
+  public void parsePqSchemeBlankFallsBackToUnknown() {
+    // null / empty / whitespace means "no PQ hint": keep the ECDSA-sized estimate.
+    assertEquals(PQScheme.UNKNOWN_PQ_SCHEME,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme(null));
+    assertEquals(PQScheme.UNKNOWN_PQ_SCHEME,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme(""));
+    assertEquals(PQScheme.UNKNOWN_PQ_SCHEME,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("   "));
+  }
+
+  @Test
+  public void parsePqSchemeByNumber() {
+    assertEquals(PQScheme.UNKNOWN_PQ_SCHEME,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("0"));
+    assertEquals(PQScheme.FN_DSA_512,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("1"));
+    assertEquals(PQScheme.ML_DSA_44,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("2"));
+    // surrounding whitespace is tolerated.
+    assertEquals(PQScheme.ML_DSA_44,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme(" 2 "));
+  }
+
+  @Test
+  public void parsePqSchemeByName() {
+    assertEquals(PQScheme.UNKNOWN_PQ_SCHEME,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("UNKNOWN_PQ_SCHEME"));
+    assertEquals(PQScheme.FN_DSA_512,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("FN_DSA_512"));
+    assertEquals(PQScheme.ML_DSA_44,
+        GetCanDelegatedMaxSizeServlet.parsePqScheme("ML_DSA_44"));
+  }
+
+  @Test
+  public void parsePqSchemeUnknownNumberThrows() {
+    // 99 is not a registered enum number; reject instead of silently ignoring.
+    assertThrows(IllegalArgumentException.class,
+        () -> GetCanDelegatedMaxSizeServlet.parsePqScheme("99"));
+  }
+
+  @Test
+  public void parsePqSchemeUnknownNameThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> GetCanDelegatedMaxSizeServlet.parsePqScheme("NOT_A_SCHEME"));
+  }
+}

--- a/protocol/src/main/protos/api/api.proto
+++ b/protocol/src/main/protos/api/api.proto
@@ -723,6 +723,9 @@ message GetAvailableUnfreezeCountResponseMessage {
 message CanDelegatedMaxSizeRequestMessage {
   int32 type = 1;
   bytes owner_address = 2;
+  // Optional. When set to a registered scheme, the BANDWIDTH estimate
+  // reserves room for the PQAuthSig wire size instead of an ECDSA signature
+  PQScheme pq_scheme = 3;
 }
 message CanDelegatedMaxSizeResponseMessage {
   int64 max_size = 1;


### PR DESCRIPTION
**What does this PR do?**

Makes `GetCanDelegatedMaxSize` account for the bandwidth a post-quantum (PQ) account's delegate transaction actually consumes.

- Adds an optional `PQScheme pq_scheme` field to `CanDelegatedMaxSizeRequestMessage`.
- When a registered scheme is supplied, the BANDWIDTH estimate reserves room for the full `PQAuthSig` wire size (via `PQSchemeRegistry.computePQAuthSigWireSize`) on top of the existing base cost, instead of assuming an ECDSA signature.
- Wires the field through gRPC (full / solidity / pbft) and the HTTP servlet. The HTTP `pq_scheme` parameter accepts either the enum name (e.g. `ML_DSA_44`) or its number, matching the POST/JsonFormat path.
- Default / `UNKNOWN_PQ_SCHEME` / ENERGY keep the previous ECDSA-sized behavior unchanged, so existing callers are unaffected.

**Why are these changes required?**

`GetCanDelegatedMaxSize` reserves room for the delegate transaction's own bandwidth via `estimateConsumeBandWidthSize`, which was hardcoded to an ECDSA-sized base (`DELEGATE_COST_BASE_SIZE = 275`). A PQ delegate transaction carries a much larger `PQAuthSig` (e.g. ML_DSA_44 ≈ 3.7 KB) instead of a ~65-byte ECDSA signature, so the estimate underestimated the real cost. As a result the queried max size was too large for PQ accounts: after delegating that amount, the account had no bandwidth left to pay for the delegate transaction itself, and the delegation could not be sent.

The node cannot know an account's PQ scheme from its address alone (the scheme is carried in-band in the transaction), so the scheme is taken as an optional caller-supplied hint. The reserve is treated as an upper bound (the full PQAuthSig size is added), so the returned max stays safely delegatable.

**This PR has been tested by:**
- Unit Tests
  - `TransactionUtilTest.estimateConsumeBandWidthSizeWithPqScheme` — exact byte reservation (`base + computePQAuthSigWireSize`), plus null/UNKNOWN no-op.
  - `WalletTest.testGetCanDelegatedMaxSizeBandWidthWithPqScheme` — PQ yields a strictly smaller max, with `ML_DSA_44 < FN_DSA_512 < ECDSA`; UNKNOWN equals the no-scheme path.
  - `GetCanDelegatedMaxSizeServletTest` — `pq_scheme` parsing by name / number / blank, and rejection of unknown values.
  - `RpcApiServicesTest.testGetCanDelegatedMaxSize` — the field flows through full / solidity / pbft.

**Extra details**

Also fixes two pre-existing `OperatorWrap` checkstyle violations in `ProposalUtilTest`.
