### PR TITLE
chore: sync upstream v4.8.2 API/P2P hardening fixes

### DIFF
--- a/common/src/main/java/org/tron/core/Constant.java
+++ b/common/src/main/java/org/tron/core/Constant.java
@@ -65,7 +65,7 @@ public class Constant {
   public static final String LOCAL_HOST = "127.0.0.1";
 
   // JSON parsing (DoS protection)
-  public static final int MAX_NESTING_DEPTH = 100;
+  public static final int MAX_NESTING_DEPTH = 20;
   public static final int MAX_TOKEN_COUNT = 100_000;
 
 }

--- a/framework/src/main/java/org/tron/common/application/HttpService.java
+++ b/framework/src/main/java/org/tron/common/application/HttpService.java
@@ -16,12 +16,22 @@
 package org.tron.common.application;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.ConnectionLimit;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.SizeLimitHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.BufferUtil;
 import org.tron.core.config.args.Args;
 
 @Slf4j(topic = "rpc")
@@ -72,6 +82,7 @@ public abstract class HttpService extends AbstractService {
     if (maxHttpConnectNumber > 0) {
       this.apiServer.addBean(new ConnectionLimit(maxHttpConnectNumber, this.apiServer));
     }
+    this.apiServer.setErrorHandler(new OversizedRequestErrorHandler());
   }
 
   protected ServletContextHandler initContextHandler() {
@@ -87,5 +98,31 @@ public abstract class HttpService extends AbstractService {
 
   protected void addFilter(ServletContextHandler context) {
 
+  }
+
+  /**
+   * For oversized requests (the 413 thrown by SizeLimitHandler during dispatch) logs the
+   * detail server-side and returns the short, uniform bad-message page, instead of the
+   * default error page that leaks the exception stack and internal request sizes. All
+   * other errors keep Jetty's default handling.
+   */
+  private static final class OversizedRequestErrorHandler extends ErrorHandler {
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request,
+        HttpServletResponse response) throws IOException, ServletException {
+      if (response.getStatus() == HttpStatus.PAYLOAD_TOO_LARGE_413) {
+        Throwable cause = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+        logger.info("Reject oversized request, uri: {}, detail: {}",
+            request.getRequestURI(), cause == null ? "413" : cause.getMessage());
+        baseRequest.setHandled(true);
+        ByteBuffer body = badMessageError(HttpStatus.PAYLOAD_TOO_LARGE_413,
+            HttpStatus.getMessage(HttpStatus.PAYLOAD_TOO_LARGE_413),
+            baseRequest.getResponse().getHttpFields());
+        response.getOutputStream().write(BufferUtil.toArray(body));
+        return;
+      }
+      super.handle(target, baseRequest, request, response);
+    }
   }
 }

--- a/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
+++ b/framework/src/main/java/org/tron/core/net/P2pEventHandlerImpl.java
@@ -215,7 +215,8 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
     }
   }
 
-  private boolean checkInvRateLimit(PeerConnection peer, InventoryMessage msg) {
+  private boolean checkInvRateLimit(PeerConnection peer, InventoryMessage msg)
+      throws P2pException {
     InventoryType invType = msg.getInventoryType();
     int currentSize = msg.getInventory().getIdsCount();
     MessageStatistics stats = peer.getPeerStatistics().messageStatistics;
@@ -237,6 +238,9 @@ public class P2pEventHandlerImpl extends P2pEventHandler {
             peer.getInetAddress(), count, currentSize, maxBlockInvIn10s);
         return false;
       }
+    } else {
+      throw new P2pException(P2pException.TypeEnum.BAD_MESSAGE,
+          "unknown inventory type: " + msg.getInventory().getTypeValue());
     }
     return true;
   }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandler.java
@@ -160,9 +160,13 @@ public class FetchInvDataMsgHandler implements TronMsgHandler {
           "FetchInvData contains duplicate hashes, size: " + hashList.size());
     }
 
-    MessageTypes type = fetchInvDataMsg.getInvMessageType();
+    InventoryType invType = fetchInvDataMsg.getInventoryType();
+    if (invType != InventoryType.TRX && invType != InventoryType.BLOCK) {
+      throw new P2pException(TypeEnum.BAD_MESSAGE,
+          "unknown inventory type: " + fetchInvDataMsg.getInventory().getTypeValue());
+    }
 
-    if (type == MessageTypes.TRX) {
+    if (invType == InventoryType.TRX) {
       for (Sha256Hash hash : fetchInvDataMsg.getHashList()) {
         if (peer.getAdvInvSpread().getIfPresent(new Item(hash, InventoryType.TRX)) == null) {
           throw new P2pException(TypeEnum.BAD_MESSAGE, "not spread inv: " + hash);

--- a/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/InventoryMsgHandler.java
@@ -63,6 +63,10 @@ public class InventoryMsgHandler implements TronMsgHandler {
     }
 
     InventoryType type = inventoryMessage.getInventoryType();
+    if (type != InventoryType.TRX && type != InventoryType.BLOCK) {
+      throw new P2pException(TypeEnum.BAD_MESSAGE,
+          "unknown inventory type: " + inventoryMessage.getInventory().getTypeValue());
+    }
     int size = hashList.size();
 
     if (peer.isNeedSyncFromPeer() || peer.isNeedSyncFromUs()) {

--- a/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
+++ b/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
@@ -57,6 +57,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Commons;
 import org.tron.common.utils.StringUtil;
+import org.tron.core.Constant;
 import org.tron.json.JSON;
 import org.tron.protos.contract.BalanceContract;
 
@@ -291,6 +292,7 @@ public class JsonFormat {
     tokenizer.consume("{"); // Needs to happen when the object starts.
     while (!tokenizer.tryConsume("}")) { // Continue till the object is done
       mergeField(tokenizer, extensionRegistry, builder, selfType);
+      tokenizer.tryConsume(",");
     }
     // Test to make sure the tokenizer has reached the end of the stream.
     if (!tokenizer.atEnd()) {
@@ -556,8 +558,9 @@ public class JsonFormat {
   }
 
   /**
-   * Parse a single field from {@code tokenizer} and merge it into {@code builder}. If a ',' is
-   * detected after the field ends, the next field will be parsed automatically
+   * Parse a single field from {@code tokenizer} and merge it into {@code builder}. Exactly one
+   * field is consumed; the caller ({@code merge} / {@code handleObject}) consumes any trailing
+   * ',' and loops over the remaining fields.
    */
   protected static void mergeField(Tokenizer tokenizer,
       ExtensionRegistry extensionRegistry, Message.Builder builder,
@@ -628,11 +631,6 @@ public class JsonFormat {
         handleValue(tokenizer, extensionRegistry, builder, field, extension, unknown, selfType);
       }
     }
-
-    if (tokenizer.tryConsume(",")) {
-      // Continue with the next field
-      mergeField(tokenizer, extensionRegistry, builder, selfType);
-    }
   }
 
   private static void handleMissingField(Tokenizer tokenizer,
@@ -642,18 +640,28 @@ public class JsonFormat {
     if ("{".equals(tokenizer.currentToken())) {
       // Message structure
       tokenizer.consume("{");
-      do {
-        tokenizer.consumeIdentifier();
-        handleMissingField(tokenizer, extensionRegistry, builder);
-      } while (tokenizer.tryConsume(","));
-      tokenizer.consume("}");
+      tokenizer.enterRecursion();
+      try {
+        do {
+          tokenizer.consumeIdentifier();
+          handleMissingField(tokenizer, extensionRegistry, builder);
+        } while (tokenizer.tryConsume(","));
+        tokenizer.consume("}");
+      } finally {
+        tokenizer.exitRecursion();
+      }
     } else if ("[".equals(tokenizer.currentToken())) {
       // Collection
       tokenizer.consume("[");
-      do {
-        handleMissingField(tokenizer, extensionRegistry, builder);
-      } while (tokenizer.tryConsume(","));
-      tokenizer.consume("]");
+      tokenizer.enterRecursion();
+      try {
+        do {
+          handleMissingField(tokenizer, extensionRegistry, builder);
+        } while (tokenizer.tryConsume(","));
+        tokenizer.consume("]");
+      } finally {
+        tokenizer.exitRecursion();
+      }
     } else { //if (!",".equals(tokenizer.currentToken)){
       // Primitive value
       if ("null".equals(tokenizer.currentToken())) {
@@ -807,20 +815,25 @@ public class JsonFormat {
     }
 
     tokenizer.consume("{");
-    String endToken = "}";
+    tokenizer.enterRecursion();
+    try {
+      String endToken = "}";
 
-    while (!tokenizer.tryConsume(endToken)) {
-      if (tokenizer.atEnd()) {
-        throw tokenizer.parseException("Expected \"" + endToken + "\".");
+      while (!tokenizer.tryConsume(endToken)) {
+        if (tokenizer.atEnd()) {
+          throw tokenizer.parseException("Expected \"" + endToken + "\".");
+        }
+        mergeField(tokenizer, extensionRegistry, subBuilder, selfType);
+        if (tokenizer.tryConsume(",")) {
+          // there are more fields in the object, so continue
+          continue;
+        }
       }
-      mergeField(tokenizer, extensionRegistry, subBuilder, selfType);
-      if (tokenizer.tryConsume(",")) {
-        // there are more fields in the object, so continue
-        continue;
-      }
+
+      return subBuilder.build();
+    } finally {
+      tokenizer.exitRecursion();
     }
-
-    return subBuilder.build();
   }
 
   /**
@@ -1290,6 +1303,18 @@ public class JsonFormat {
     // errors *after* consuming).
     private int previousLine = 0;
     private int previousColumn = 0;
+    private int currentDepth = 0;
+
+    public void enterRecursion() throws ParseException {
+      if (currentDepth >= Constant.MAX_NESTING_DEPTH) {
+        throw parseException("Hit recursion limit.");
+      }
+      ++currentDepth;
+    }
+
+    public void exitRecursion() {
+      --currentDepth;
+    }
 
     /**
      * Construct a tokenizer that parses tokens from the given text.

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/JsonRpcServlet.java
@@ -3,6 +3,7 @@ package org.tron.core.services.jsonrpc;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -114,7 +115,11 @@ public class JsonRpcServlet extends RateLimiterServlet {
         return;
       }
     } catch (JsonProcessingException e) {
-      writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, "JSON parse error", null, false);
+      if (e instanceof StreamConstraintsException) {
+        writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, e.getMessage(), null, false);
+      } else {
+        writeJsonRpcError(resp, JsonRpcError.PARSE_ERROR, "JSON parse error", null, false);
+      }
       return;
     }
 

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1143,7 +1143,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
         String abiStr = "{" + "\"entrys\":" + args.getAbi() + "}";
         try {
           JsonFormat.merge(abiStr, abiBuilder, args.isVisible());
-        } catch (StackOverflowError e) {
+        } catch (JsonFormat.ParseException | StackOverflowError e) {
           throw new JsonRpcInvalidParamsException("invalid abi");
         }
       }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1548,7 +1548,8 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
   }
 
   @Override
-  public LogFilterElement[] getFilterLogs(String filterId) throws ExecutionException,
+  public LogFilterElement[] getFilterLogs(String filterId) throws
+      JsonRpcInvalidParamsException, ExecutionException,
       InterruptedException, BadItemException, ItemNotFoundException,
       JsonRpcMethodNotFoundException, JsonRpcTooManyResultException {
     disableInPBFT("eth_getFilterLogs");
@@ -1567,6 +1568,10 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
 
     LogFilterWrapper logFilterWrapper = eventFilter2Result.get(filterId).getLogFilterWrapper();
     long currentMaxBlockNum = wallet.getNowBlock().getBlockHeader().getRawData().getNumber();
+
+    // re-check the block range against the current head: the filter was created without the cap
+    // (eth_newFilter), so enforce it here to prevent an unbounded scan.
+    logFilterWrapper.validateBlockRange(currentMaxBlockNum);
 
     return getLogsByLogFilterWrapper(logFilterWrapper, currentMaxBlockNum);
   }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/TronJsonRpcImpl.java
@@ -1143,7 +1143,7 @@ public class TronJsonRpcImpl implements TronJsonRpc, Closeable {
         String abiStr = "{" + "\"entrys\":" + args.getAbi() + "}";
         try {
           JsonFormat.merge(abiStr, abiBuilder, args.isVisible());
-        } catch (JsonFormat.ParseException | StackOverflowError e) {
+        } catch (Exception e) {
           throw new JsonRpcInvalidParamsException("invalid abi");
         }
       }

--- a/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/filters/LogFilterWrapper.java
@@ -98,16 +98,23 @@ public class LogFilterWrapper {
           throw new JsonRpcInvalidParamsException("please verify: fromBlock <= toBlock");
         }
       }
-
-      // till now, it needs to check block range for eth_getLogs
-      int maxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
-      if (checkBlockRange && maxBlockRange > 0
-          && min(toBlockSrc, currentMaxBlockNum) - fromBlockSrc > maxBlockRange) {
-        throw new JsonRpcInvalidParamsException("exceed max block range: " + maxBlockRange);
-      }
     }
 
     this.fromBlock = fromBlockSrc;
     this.toBlock = toBlockSrc;
+
+    // eth_getLogs enforces the block range at construction time. eth_newFilter creates the
+    // wrapper with checkBlockRange=false (no creation-time gate); eth_getFilterLogs re-runs this
+    // check against the current head before scanning so the cap cannot be bypassed.
+    if (checkBlockRange) {
+      validateBlockRange(currentMaxBlockNum);
+    }
+  }
+
+  public void validateBlockRange(long currentMaxBlockNum) throws JsonRpcInvalidParamsException {
+    int maxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
+    if (maxBlockRange > 0 && min(toBlock, currentMaxBlockNum) - fromBlock > maxBlockRange) {
+      throw new JsonRpcInvalidParamsException("exceed max block range: " + maxBlockRange);
+    }
   }
 }

--- a/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
+++ b/framework/src/test/java/org/tron/common/jetty/SizeLimitHandlerTest.java
@@ -1,8 +1,12 @@
 package org.tron.common.jetty;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServlet;
@@ -33,7 +37,7 @@ import org.tron.json.JSONObject;
 
 /**
  * Tests {@link org.eclipse.jetty.server.handler.SizeLimitHandler} body-size
- * enforcement configured in {@link HttpService#initContextHandler()}.
+ * enforcement configured in {@link HttpService}.
  *
  * Covers: accept/reject by size, UTF-8 byte counting, independent limits
  * across HttpService instances, chunked transfer, and zero-limit behavior.
@@ -152,10 +156,69 @@ public class SizeLimitHandlerTest {
     Assert.assertEquals(200, post(httpServerUri, new StringEntity("small body")));
   }
 
+  /**
+   * An oversized request must return 413 carrying the short, uniform bad-message
+   * page produced by the custom ErrorHandler in {@link HttpService} -
+   * not the default Jetty error page that leaks the exception stack, class name
+   * and the internal request size.
+   */
   @Test
   public void testHttpBodyExceedsLimit() throws Exception {
-    Assert.assertEquals(413,
-        post(httpServerUri, new StringEntity(repeat('a', HTTP_MAX_BODY_SIZE + 1))));
+    HttpPost req = new HttpPost(httpServerUri);
+    req.setEntity(new StringEntity(repeat('a', HTTP_MAX_BODY_SIZE + 1)));
+    HttpResponse resp = client.execute(req);
+
+    String body = EntityUtils.toString(resp.getEntity());
+
+    // return value: 413
+    Assert.assertEquals(413, resp.getStatusLine().getStatusCode());
+
+    // returned page: short uniform bad-message page with the generic reason
+    Assert.assertTrue("should render the short bad-message page",
+        body.contains("Bad Message 413"));
+    Assert.assertTrue("reason should be the generic status message",
+        body.contains("Payload Too Large"));
+
+    // must NOT leak Jetty internals
+    Assert.assertFalse("must not leak exception class / stack frames",
+        body.contains("org.eclipse.jetty"));
+  }
+
+  /**
+   * A malformed Content-Length is rejected by the HTTP parser (onBadMessage ->
+   * ErrorHandler.badMessageError()), a different path from the 413 dispatch handler.
+   * Confirms the custom ErrorHandler leaves other 4xx untouched: still the default
+   * 400 bad-message page, not rerouted through the 413 branch.
+   */
+  @Test
+  public void testBadContentLengthReturnsDefault400() throws Exception {
+    String raw = "POST / HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "Content-Length: +450\r\n"
+        + "\r\n";
+    String resp = sendRaw(httpServerUri, raw);
+
+    Assert.assertTrue("expected 400, got: " + firstLine(resp), resp.startsWith("HTTP/1.1 400"));
+    Assert.assertTrue("should be the default bad-message page", resp.contains("Bad Message 400"));
+    Assert.assertFalse("must not be rerouted through the 413 branch",
+        resp.contains("Payload Too Large"));
+  }
+
+  /**
+   * A request-line URI longer than the request header buffer is rejected by the HTTP
+   * parser (414), again via badMessageError(), not the 413 dispatch handler. Confirms it
+   * is unaffected by the custom ErrorHandler.
+   */
+  @Test
+  public void testOversizedUriReturnsDefault414() throws Exception {
+    String raw = "GET /" + repeat('a', 9000) + " HTTP/1.1\r\n"  // request line > default 8KB
+        + "Host: localhost\r\n"
+        + "\r\n";
+    String resp = sendRaw(httpServerUri, raw);
+
+    Assert.assertTrue("expected 414, got: " + firstLine(resp), resp.startsWith("HTTP/1.1 414"));
+    Assert.assertFalse("must not be rerouted through the 413 branch",
+        resp.contains("Payload Too Large"));
   }
 
   @Test
@@ -323,5 +386,27 @@ public class SizeLimitHandlerTest {
   /** Returns a string of {@code n} repetitions of {@code c}. */
   private static String repeat(char c, int n) {
     return new String(new char[n]).replace('\0', c);
+  }
+
+  /** Sends a raw HTTP request over a socket and returns the full response (until EOF). */
+  private static String sendRaw(URI uri, String rawRequest) throws Exception {
+    try (Socket socket = new Socket(uri.getHost(), uri.getPort())) {
+      socket.getOutputStream().write(rawRequest.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      InputStream in = socket.getInputStream();
+      byte[] buf = new byte[4096];
+      int n;
+      while ((n = in.read(buf)) != -1) {
+        out.write(buf, 0, n);
+      }
+      return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /** First line (status line) of a raw HTTP response. */
+  private static String firstLine(String resp) {
+    int idx = resp.indexOf("\r\n");
+    return idx < 0 ? resp : resp.substring(0, idx);
   }
 }

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -1461,9 +1461,8 @@ public class JsonrpcServiceTest extends BaseTest {
 
   @Test
   public void testBuildTransactionRejectsDeeplyNestedAbi() {
-    // A pathological ABI with deep nesting overflows the recursive JsonFormat parser.
-    // buildCreateSmartContractTransaction must surface this as invalid-params (-32602),
-    // not let a StackOverflowError escape as a generic internal error.
+    // A deeply nested ABI must surface as invalid-params (-32602), not as a generic
+    // internal error.
     int depth = 200_000;
     StringBuilder abi = new StringBuilder("[],\"x\":");
     for (int i = 0; i < depth; i++) {

--- a/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
+++ b/framework/src/test/java/org/tron/core/jsonrpc/JsonrpcServiceTest.java
@@ -1329,6 +1329,35 @@ public class JsonrpcServiceTest extends BaseTest {
   }
 
   @Test
+  public void testGetFilterLogsEnforcesBlockRange() throws Exception {
+    int oldMaxBlockRange = Args.getInstance().getJsonRpcMaxBlockRange();
+    Args.getInstance().setJsonRpcMaxBlockRange(5_000);
+    try {
+      // toBlock=0xf4240 (1_000_000) is clamped to head (LATEST_BLOCK_NUM = 10_000), so the span
+      // is min(1_000_000, 10_000) - 0 = 10_000 > 5_000 cap.
+      String wideFilterId = tronJsonRpc.newFilter(
+          new FilterRequest("0x0", "0xf4240", null, null, null));
+      Assert.assertNotNull(wideFilterId);
+
+      // eth_getFilterLogs must reject it at query time (previously bypassed -> unbounded scan).
+      JsonRpcInvalidParamsException ex = Assert.assertThrows(
+          JsonRpcInvalidParamsException.class,
+          () -> tronJsonRpc.getFilterLogs(wideFilterId));
+      Assert.assertEquals("exceed max block range: 5000", ex.getMessage());
+
+      // A within-cap filter (span 0) is still served normally - no false rejection.
+      String headHex = ByteArray.toJsonHex(blockCapsule1.getNum());
+      int expectedLogs = blockCapsule1.getTransactions().size() * 2;
+      String okFilterId = tronJsonRpc.newFilter(
+          new FilterRequest(headHex, headHex, null, null, null));
+      LogFilterElement[] okResult = tronJsonRpc.getFilterLogs(okFilterId);
+      Assert.assertEquals(expectedLogs, okResult.length);
+    } finally {
+      Args.getInstance().setJsonRpcMaxBlockRange(oldMaxBlockRange);
+    }
+  }
+
+  @Test
   public void testGetBlockReceipts() {
 
     try {

--- a/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
+++ b/framework/src/test/java/org/tron/core/net/P2pEventHandlerImplTest.java
@@ -3,6 +3,7 @@ package org.tron.core.net;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.google.protobuf.ByteString;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -210,6 +211,35 @@ public class P2pEventHandlerImplTest extends BaseTest {
     method.invoke(handler, peer, msgBlock1.getSendBytes());
     Assert.assertEquals(100,  // count unchanged: message was dropped
         peer.getPeerStatistics().messageStatistics.tronInBlockInventoryElement.getCount(10));
+  }
+
+  @Test
+  public void testCheckInvRateLimitUnknownTypeRejected() throws Exception {
+    CommonParameter parameter = CommonParameter.getInstance();
+    parameter.setMaxTps(10);
+    parameter.setMaxBlockInvPerSecond(10);
+
+    PeerStatistics peerStatistics = new PeerStatistics();
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getPeerStatistics()).thenReturn(peerStatistics);
+
+    P2pEventHandlerImpl handler = new P2pEventHandlerImpl();
+    Method method = handler.getClass()
+        .getDeclaredMethod("processMessage", PeerConnection.class, byte[].class);
+    method.setAccessible(true);
+
+    // craft an Inventory whose enum type holds an undefined value (2)
+    Protocol.Inventory inv = Protocol.Inventory.newBuilder()
+        .setTypeValue(2)
+        .addIds(ByteString.copyFrom(new byte[32]))
+        .build();
+    InventoryMessage msg = new InventoryMessage(inv.toByteArray());
+    Assert.assertEquals(InventoryType.UNRECOGNIZED, msg.getInventoryType());
+
+    method.invoke(handler, peer, msg.getSendBytes());
+
+    // checkInvRateLimit throws BAD_MESSAGE -> processException -> disconnect(BAD_PROTOCOL)
+    verify(peer).disconnect(Protocol.ReasonCode.BAD_PROTOCOL);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/FetchInvDataMsgHandlerTest.java
@@ -157,6 +157,27 @@ public class FetchInvDataMsgHandlerTest {
   }
 
   @Test
+  public void testUnknownInventoryTypeRejected() throws Exception {
+    FetchInvDataMsgHandler handler = new FetchInvDataMsgHandler();
+    PeerConnection peer = Mockito.mock(PeerConnection.class);
+
+    // craft a FetchInvData whose enum type holds an undefined value (2)
+    Protocol.Inventory inv = Protocol.Inventory.newBuilder()
+        .setTypeValue(2)
+        .addIds(com.google.protobuf.ByteString.copyFrom(new byte[32]))
+        .build();
+    FetchInvDataMessage msg = new FetchInvDataMessage(inv.toByteArray());
+    Assert.assertEquals(Protocol.Inventory.InventoryType.UNRECOGNIZED, msg.getInventoryType());
+
+    try {
+      handler.processMessage(peer, msg);
+      Assert.fail("Expected P2pException for unknown inventory type");
+    } catch (P2pException e) {
+      Assert.assertEquals(P2pException.TypeEnum.BAD_MESSAGE, e.getType());
+    }
+  }
+
+  @Test
   public void testRateLimiter() {
     List<Sha256Hash> blockIds = new LinkedList<>();
     for (int i = 0; i <= 100; i++) {

--- a/framework/src/test/java/org/tron/core/net/messagehandler/InventoryMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/InventoryMsgHandlerTest.java
@@ -2,6 +2,7 @@ package org.tron.core.net.messagehandler;
 
 import static org.mockito.Mockito.mock;
 
+import com.google.protobuf.ByteString;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -18,6 +19,7 @@ import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.message.adv.InventoryMessage;
 import org.tron.core.net.peer.PeerConnection;
 import org.tron.p2p.connection.Channel;
+import org.tron.protos.Protocol.Inventory;
 import org.tron.protos.Protocol.Inventory.InventoryType;
 
 public class InventoryMsgHandlerTest {
@@ -69,6 +71,30 @@ public class InventoryMsgHandlerTest {
     try {
       handler.processMessage(peer, msg);
       Assert.fail("Expected P2pException for duplicate hashes");
+    } catch (P2pException e) {
+      Assert.assertEquals(P2pException.TypeEnum.BAD_MESSAGE, e.getType());
+    }
+  }
+
+  @Test
+  public void testUnknownInventoryTypeRejected() throws Exception {
+    InventoryMsgHandler handler = new InventoryMsgHandler();
+    Args.setParam(new String[] {}, TestConstants.TEST_CONF);
+
+    // craft an Inventory whose enum type holds an undefined value (2)
+    Inventory inv = Inventory.newBuilder()
+        .setTypeValue(2)
+        .addIds(ByteString.copyFrom(new byte[32]))
+        .build();
+    InventoryMessage msg = new InventoryMessage(inv.toByteArray());
+    Assert.assertEquals(InventoryType.UNRECOGNIZED, msg.getInventoryType());
+
+    PeerConnection peer = new PeerConnection();
+    peer.setChannel(getChannel("1.0.0.5", 1000));
+
+    try {
+      handler.processMessage(peer, msg);
+      Assert.fail("Expected P2pException for unknown inventory type");
     } catch (P2pException e) {
       Assert.assertEquals(P2pException.TypeEnum.BAD_MESSAGE, e.getType());
     }

--- a/framework/src/test/java/org/tron/core/services/http/JsonFormatTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/JsonFormatTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.tron.core.Constant;
 import org.tron.protos.Protocol;
 
 public class JsonFormatTest {
@@ -250,6 +251,187 @@ public class JsonFormatTest {
     });
     cause = thrown.getCause();
     assertTrue(cause instanceof NumberFormatException);
+  }
+
+  /*
+   * Compatibility-preserved behavior: these cases pass before and after this fix.
+   * They guard unknown-field skipping, repeated-field syntax, and accepted depth.
+   */
+  @Test
+  public void testMissingFieldSkipsNestedObjectAndArray() throws Exception {
+    String input = "{\"zzz\":{\"a\":1,\"b\":[true,false,null,{\"c\":\"d\"}],\"e\":{\"f\":2}},"
+        + "\"address\":\"61646472657373\"}";
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+
+    JsonFormat.merge(input, builder, false);
+
+    assertEquals(ByteString.copyFromUtf8("address"), builder.getAddress());
+  }
+
+  @Test
+  public void testTrailingCommaInKnownRepeatedField() throws Exception {
+    Protocol.Proposal.Builder builder = Protocol.Proposal.newBuilder();
+
+    JsonFormat.merge("{\"approvals\":[\"00\",\"01\",]}", builder, false);
+
+    Protocol.Proposal proposal = builder.build();
+    assertEquals(2, proposal.getApprovalsCount());
+    assertEquals(ByteString.copyFrom(new byte[] {0}), proposal.getApprovals(0));
+    assertEquals(ByteString.copyFrom(new byte[] {1}), proposal.getApprovals(1));
+  }
+
+  @Test
+  public void testKnownRepeatedPrimitiveFieldRejectsNestedArray() {
+    Protocol.Proposal.Builder builder = Protocol.Proposal.newBuilder();
+
+    JsonFormat.ParseException e = assertThrows(JsonFormat.ParseException.class,
+        () -> JsonFormat.merge("{\"approvals\":[[\"00\"]]}", builder, false));
+
+    assertTrue(e.getMessage().contains("Expected string."));
+  }
+
+  @Test
+  public void testKnownRepeatedMessageFieldRejectsNestedArray() {
+    Protocol.Block.Builder builder = Protocol.Block.newBuilder();
+
+    JsonFormat.ParseException e = assertThrows(JsonFormat.ParseException.class,
+        () -> JsonFormat.merge("{\"transactions\":[[]]}", builder, false));
+
+    assertTrue(e.getMessage().contains("Expected \"{\"."));
+  }
+
+  @Test
+  public void testMissingFieldRejectsTrailingCommaInNestedObject() {
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+
+    JsonFormat.ParseException e = assertThrows(JsonFormat.ParseException.class,
+        () -> JsonFormat.merge("{\"zzz\":{\"a\":1,}}", builder));
+
+    assertTrue(e.getMessage().contains("Expected identifier"));
+  }
+
+  @Test
+  public void testMissingFieldRejectsTrailingCommaInNestedArray() {
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+
+    JsonFormat.ParseException e = assertThrows(JsonFormat.ParseException.class,
+        () -> JsonFormat.merge("{\"zzz\":[1,]}", builder));
+
+    assertTrue(e.getMessage().contains("Expected string."));
+  }
+
+  @Test
+  public void testNestingWithinLimit() throws Exception {
+    int depth = Constant.MAX_NESTING_DEPTH / 2;
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < depth; i++) {
+      sb.append("{\"zzz\":");
+    }
+    sb.append("1");
+    for (int i = 0; i < depth; i++) {
+      sb.append("}");
+    }
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+    JsonFormat.merge(sb.toString(), builder);
+    assertNotNull(builder.build());
+  }
+
+  /*
+   * Behavior changed by this fix: the previous parser either missed the depth guard
+   * or failed through recursive comma handling / stack overflow.
+   */
+  @Test
+  public void testTrailingCommaInParsedObjects() throws Exception {
+    String input = "{\"genesisBlockId\":{\"hash\":\"00\",\"number\":1,},"
+        + "\"address\":\"61646472657373\",}";
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+
+    JsonFormat.merge(input, builder, false);
+
+    Protocol.HelloMessage message = builder.build();
+    assertEquals(ByteString.copyFrom(new byte[] {0}), message.getGenesisBlockId().getHash());
+    assertEquals(1L, message.getGenesisBlockId().getNumber());
+    assertEquals(ByteString.copyFromUtf8("address"), message.getAddress());
+  }
+
+  @Test
+  public void testMissingFieldRejectsObjectBeyondNestingLimit() {
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+
+    JsonFormat.ParseException e = assertThrows(JsonFormat.ParseException.class,
+        () -> JsonFormat.merge(buildUnknownNestedObject(Constant.MAX_NESTING_DEPTH + 1), builder));
+
+    assertTrue(e.getMessage().contains("Hit recursion limit."));
+  }
+
+  @Test
+  public void testMissingFieldRejectsArrayBeyondNestingLimit() {
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+
+    JsonFormat.ParseException e = assertThrows(JsonFormat.ParseException.class,
+        () -> JsonFormat.merge(buildUnknownNestedArray(Constant.MAX_NESTING_DEPTH + 1), builder));
+
+    assertTrue(e.getMessage().contains("Hit recursion limit."));
+  }
+
+  @Test
+  public void testDeeplyNestedObject() {
+    int depth = 100_000;
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < depth; i++) {
+      sb.append("{\"zzz\":");
+    }
+    sb.append("1");
+    for (int i = 0; i < depth; i++) {
+      sb.append("}");
+    }
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+    assertThrows(JsonFormat.ParseException.class, () -> JsonFormat.merge(sb.toString(), builder));
+  }
+
+  @Test
+  public void testDeeplyNestedArray() {
+    int depth = 100_000;
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"zzz\":");
+    for (int i = 0; i < depth; i++) {
+      sb.append("[");
+    }
+    sb.append("1");
+    for (int i = 0; i < depth; i++) {
+      sb.append("]");
+    }
+    sb.append("}");
+    Protocol.HelloMessage.Builder builder = Protocol.HelloMessage.newBuilder();
+    assertThrows(JsonFormat.ParseException.class, () -> JsonFormat.merge(sb.toString(), builder));
+  }
+
+  private String buildUnknownNestedObject(int depth) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    for (int i = 0; i < depth; i++) {
+      sb.append("\"zzz\":{");
+    }
+    sb.append("\"leaf\":1");
+    for (int i = 0; i < depth; i++) {
+      sb.append("}");
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private String buildUnknownNestedArray(int depth) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"zzz\":");
+    for (int i = 0; i < depth; i++) {
+      sb.append("[");
+    }
+    sb.append("1");
+    for (int i = 0; i < depth; i++) {
+      sb.append("]");
+    }
+    sb.append("}");
+    return sb.toString();
   }
 
 }

--- a/framework/src/test/java/org/tron/core/services/http/TriggerConstantContractServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/TriggerConstantContractServletTest.java
@@ -1,0 +1,49 @@
+package org.tron.core.services.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.tron.common.crypto.ECKey;
+import org.tron.common.utils.ByteArray;
+import org.tron.core.capsule.TransactionCapsule;
+
+public class TriggerConstantContractServletTest extends BaseHttpTest {
+
+  private TriggerConstantContractServlet servlet;
+
+  @Override
+  protected void setUpMocks() throws Exception {
+    servlet = new TriggerConstantContractServlet();
+    injectWallet(servlet);
+  }
+
+  @Test
+  public void testManyFlatFieldsDoesNotOverflowStack() throws Exception {
+    String owner = ByteArray.toHexString(new ECKey().getAddress());
+    String contract = ByteArray.toHexString(new ECKey().getAddress());
+
+    StringBuilder body = new StringBuilder(256 * 1024)
+        .append("{\"owner_address\":\"").append(owner).append('"')
+        .append(",\"contract_address\":\"").append(contract).append('"')
+        .append(",\"data\":\"00\"");
+    for (int i = 0; i < 20_000; i++) {
+      body.append(",\"x").append(i).append("\":1");
+    }
+    body.append('}');
+
+    when(wallet.createTransactionCapsule(any(), any()))
+        .thenReturn(new TransactionCapsule(MINIMAL_TX));
+    when(wallet.triggerConstantContract(any(), any(), any(), any()))
+        .thenReturn(MINIMAL_TX);
+
+    MockHttpServletResponse response = newResponse();
+    servlet.doPost(postRequest(body.toString()), response);
+
+    assertEquals(200, response.getStatus());
+    verify(wallet).triggerConstantContract(any(), any(), any(), any());
+  }
+}

--- a/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
+++ b/framework/src/test/java/org/tron/core/services/jsonrpc/JsonRpcServletTest.java
@@ -3,6 +3,7 @@ package org.tron.core.services.jsonrpc;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -62,6 +63,8 @@ public class JsonRpcServletTest {
     JsonNode body = MAPPER.readTree(resp.getContentAsString());
     assertFalse(body.isArray());
     assertEquals(-32700, body.get("error").get("code").asInt());
+    // A non-constraint JsonProcessingException keeps the generic message (else branch).
+    assertEquals("JSON parse error", body.get("error").get("message").asText());
     assertEquals("2.0", body.get("jsonrpc").asText());
     assertTrue(body.get("id").isNull());
   }
@@ -378,8 +381,14 @@ public class JsonRpcServletTest {
 
     MockHttpServletResponse resp = doPost(sb.toString());
     assertEquals(200, resp.getStatus());
-    assertEquals(-32700,
-        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    JsonNode error = MAPPER.readTree(resp.getContentAsString()).get("error");
+    assertEquals(-32700, error.get("code").asInt());
+    // StreamConstraintsException message must be surfaced verbatim, not the generic text,
+    // so callers can tell which constraint (nesting depth) was hit.
+    String message = error.get("message").asText();
+    assertNotEquals("JSON parse error", message);
+    assertTrue("expected a nesting-depth constraint message, got: " + message,
+        message.contains("nesting depth") && message.contains("exceeds the maximum allowed"));
   }
 
   @Test
@@ -396,8 +405,14 @@ public class JsonRpcServletTest {
 
     MockHttpServletResponse resp = doPost(sb.toString());
     assertEquals(200, resp.getStatus());
-    assertEquals(-32700,
-        MAPPER.readTree(resp.getContentAsString()).get("error").get("code").asInt());
+    JsonNode error = MAPPER.readTree(resp.getContentAsString()).get("error");
+    assertEquals(-32700, error.get("code").asInt());
+    // StreamConstraintsException message must be surfaced verbatim, not the generic text,
+    // so callers can tell which constraint (token count) was hit.
+    String message = error.get("message").asText();
+    assertNotEquals("JSON parse error", message);
+    assertTrue("expected a token-count constraint message, got: " + message,
+        message.contains("Token count") && message.contains("exceeds the maximum allowed"));
   }
 
   // --- helpers ---


### PR DESCRIPTION
 ## Summary

  Syncs the Nile branch with the latest hardening fixes from upstream
  `tronprotocol/java-tron:release_v4.8.2`. This brings in 5 commits focused
  on API input validation, JSON-RPC limits, and P2P message safety — no
  consensus or protocol behavior changes.

  ## Changes

  - **fix(net): reject unknown inventory type in P2P inv/fetch-inv handling (#6851)**
    Validates the inventory type in `InventoryMsgHandler` / `FetchInvDataMsgHandler`
    so malformed `inv` / `fetch-inv` messages are rejected instead of processed.

  - **fix(api): tighten JSON parsing limits (#6844)**
    Hardens `JsonFormat` parsing with stricter limits to guard against
    oversized / malformed request payloads.

  - **fix(jsonrpc): enforce maxBlockRange on eth_getFilterLogs (#6842)**
    Applies the `maxBlockRange` cap to `eth_getFilterLogs` via `LogFilterWrapper`,
    preventing unbounded log range queries.

  - **refactor(http): improve JsonFormat parser robustness (#6845)**
    Makes the HTTP `JsonFormat` parser more robust against edge-case input.

  - **fix(api): hide Jetty internals in oversized request 413 response (#6843)**
    Adds `HttpService` handling so 413 (request too large) responses no longer
    leak internal Jetty details.
