### PR TITLE
fix: add more PQ check guard

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -207,7 +207,7 @@ public class TransactionUtil {
     TransactionSignWeight.Builder tswBuilder = TransactionSignWeight.newBuilder();
     Result.Builder resultBuilder = Result.newBuilder();
     int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
-    if (trx.getSignatureCount() + trx.getPqAuthSigCount() > totalSignNum) {
+    if (new TransactionCapsule(trx).getTotalSignatureCount() > totalSignNum) {
       resultBuilder.setCode(Result.response_code.OTHER_ERROR);
       resultBuilder.setMessage("too many signatures");
       tswBuilder.setResult(resultBuilder);

--- a/chainbase/src/main/java/org/tron/common/utils/LocalWitnesses.java
+++ b/chainbase/src/main/java/org/tron/common/utils/LocalWitnesses.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.encoders.DecoderException;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.crypto.SignInterface;
 import org.tron.common.crypto.SignUtils;
@@ -185,10 +186,10 @@ public class LocalWitnesses {
         throw new TronError("unsupported PQ signature scheme: " + scheme,
             TronError.ErrCode.WITNESS_INIT);
       }
-      int expectedPrivLen = PQSchemeRegistry.getPrivateKeyLength(scheme);
-      int expectedPubLen = PQSchemeRegistry.getPublicKeyLength(scheme);
-      validatePqKey(kp.getPrivateKey(), expectedPrivLen, "PQ private key");
-      validatePqKey(kp.getPublicKey(), expectedPubLen, "PQ public key");
+      int expectedPrivByteLen = PQSchemeRegistry.getPrivateKeyLength(scheme);
+      int expectedPubByteLen = PQSchemeRegistry.getPublicKeyLength(scheme);
+      validatePqKey(kp.getPrivateKey(), expectedPrivByteLen, "PQ private key");
+      validatePqKey(kp.getPublicKey(), expectedPubByteLen, "PQ public key");
       try {
         PQSchemeRegistry.fromKeypair(scheme,
             ByteArray.fromHexString(kp.getPrivateKey()),
@@ -201,19 +202,17 @@ public class LocalWitnesses {
     this.pqKeypairs = pqKeypairs;
   }
 
-  private static void validatePqKey(String key, int expectedLen, String label) {
-    String hex = key;
+  private static void validatePqKey(String key, int expectedByteLen, String label) {
     // Match downstream ByteArray.fromHexString, which only strips lowercase "0x".
-    if (StringUtils.startsWith(hex, "0x")) {
-      hex = hex.substring(2);
-    }
-    int expectedHexLen = expectedLen * 2;
-    if (StringUtils.isBlank(hex) || hex.length() != expectedHexLen) {
-      throw new TronError(String.format("%s must be %d hex chars, actual: %d",
-          label, expectedHexLen, StringUtils.isBlank(hex) ? 0 : hex.length()),
+    String hex = StringUtils.removeStart(key, "0x");
+    if (StringUtils.length(hex) != expectedByteLen * 2) {
+      throw new TronError(String.format("%s must be %d bytes", label, expectedByteLen),
           TronError.ErrCode.WITNESS_INIT);
     }
-    if (!StringUtil.isHexadecimal(hex)) {
+    try {
+      // Length is already correct; this validates the hex characters themselves.
+      ByteArray.fromHexString(key);
+    } catch (DecoderException e) {
       throw new TronError(label + " must be hex string", TronError.ErrCode.WITNESS_INIT);
     }
   }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -466,7 +466,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return ECDSASignature.fromComponents(rsv.getR(), rsv.getS(), rsv.getV()).toBase64();
   }
 
-  public static boolean validateSignature(Transaction transaction,
+  private static boolean validateSignature(Transaction transaction,
       byte[] hash, AccountStore accountStore, DynamicPropertiesStore dynamicPropertiesStore)
       throws PermissionException, SignatureException, SignatureFormatException {
     Transaction.Contract contract = transaction.getRawData().getContractList().get(0);
@@ -676,8 +676,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
       if (signatureCount == 0 || this.transaction.getRawData().getContractCount() <= 0) {
         throw new ValidateSignatureException("miss sig or contract");
       }
-      int totalSignNum = dynamicPropertiesStore.getTotalSignNum();
-      if (signatureCount > totalSignNum) {
+      if (signatureCount > dynamicPropertiesStore.getTotalSignNum()) {
         throw new ValidateSignatureException("too many signatures");
       }
 
@@ -806,8 +805,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         if (!ArrayUtils.isEmpty(owner)) { //transfer from transparent address
           validatePubSignature(accountStore, dynamicPropertiesStore);
         } else { //transfer from shielded address
-          if (this.transaction.getSignatureCount() > 0
-              || (this.transaction.getPqAuthSigCount() > 0)) {
+          if (this.getTotalSignatureCount() > 0) {
             throw new ValidateSignatureException("there should be no signatures signed by "
                     + "transparent address when transfer from shielded address");
           }

--- a/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
@@ -72,8 +72,6 @@ public class MetricKeys {
      * Transaction fetch round-trip latency in seconds: from sending
      * {@code GET_DATA (FETCH_INV_DATA)} to receiving the full {@code TXS}
      * message.
-     * <p>Transactions pushed via gossip without a prior {@code GET_DATA}
-     * (i.e. not actively fetched by this node) are <b>not sampled</b>;
      * <p>Companion to {@link #BLOCK_FETCH_LATENCY} for the TX path.
      */
     public static final String TX_FETCH_LATENCY = "tron:tx_fetch_latency_seconds";

--- a/crypto/src/main/java/org/tron/common/crypto/pqc/PQAuthSigValidator.java
+++ b/crypto/src/main/java/org/tron/common/crypto/pqc/PQAuthSigValidator.java
@@ -30,7 +30,7 @@ public final class PQAuthSigValidator {
     if (!PQSchemeRegistry.contains(scheme)) {
       return false;
     }
-    return pqAuthSig.getPublicKey().size() <= PQSchemeRegistry.getPublicKeyLength(scheme)
-        && pqAuthSig.getSignature().size() <= PQSchemeRegistry.getSignatureLength(scheme);
+    return pqAuthSig.getPublicKey().size() == PQSchemeRegistry.getPublicKeyLength(scheme)
+        && PQSchemeRegistry.isValidSignatureLength(scheme, pqAuthSig.getSignature().size());
   }
 }

--- a/crypto/src/main/java/org/tron/common/crypto/pqc/PQSchemeRegistry.java
+++ b/crypto/src/main/java/org/tron/common/crypto/pqc/PQSchemeRegistry.java
@@ -73,8 +73,12 @@ public final class PQSchemeRegistry {
   @AllArgsConstructor
   private static final class SchemeInfo {
 
+    // All *Length fields below are byte counts (not hex chars, not bits).
     final int privateKeyLength;
     final int publicKeyLength;
+    // Upper bound of the signature-length band: the exact length for
+    // fixed-length schemes (Dilithium), the maximum for variable-length
+    // schemes (Falcon, registered as SIGNATURE_MAX_LENGTH).
     final int signatureLength;
     // Lower bound of the signature-length band. Equal to signatureLength for
     // fixed-length schemes (Dilithium); strictly less for variable-length

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -517,7 +517,7 @@ public class Wallet {
       int totalSignNum = chainBaseManager.getDynamicPropertiesStore().getTotalSignNum();
       if (totalSignCount > totalSignNum) {
         String info = "total signature count " + totalSignCount + " exceeds " + totalSignNum;
-        logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
+        logger.warn(BROADCAST_TRANS_FAILED, txID, info);
         return builder.setResult(false).setCode(response_code.SIGERROR)
             .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
             .build();
@@ -526,17 +526,26 @@ public class Wallet {
       for (ByteString sig : signedTransaction.getSignatureList()) {
         if (!SignUtils.isValidLength(sig.size())) {
           String info = "Signature size is " + sig.size();
-          logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
+          logger.warn(BROADCAST_TRANS_FAILED, txID, info);
           return builder.setResult(false).setCode(response_code.SIGERROR)
               .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
               .build();
         }
       }
 
+      if (signedTransaction.getPqAuthSigCount() > 0
+          && !chainBaseManager.getDynamicPropertiesStore().isAnyPqSchemeAllowed()) {
+        String info = "pq_auth_sig not allowed: no post-quantum scheme is activated";
+        logger.warn(BROADCAST_TRANS_FAILED, txID, info);
+        return builder.setResult(false).setCode(response_code.SIGERROR)
+            .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
+            .build();
+      }
+
       for (PQAuthSig pqAuthSig : signedTransaction.getPqAuthSigList()) {
         if (!PQAuthSigValidator.isLengthWithinBounds(pqAuthSig)) {
           String info = "pq_auth_sig size is out of bounds";
-          logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
+          logger.warn(BROADCAST_TRANS_FAILED, txID, info);
           return builder.setResult(false).setCode(response_code.SIGERROR)
               .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
               .build();

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -171,6 +171,13 @@ public class TransactionsMsgHandler implements TronMsgHandler {
               "tx " + item.getHash() + " signature size is " + sig.size());
         }
       }
+
+      if (trx.getPqAuthSigCount() > 0
+          && !chainBaseManager.getDynamicPropertiesStore().isAnyPqSchemeAllowed()) {
+        String info = "pq_auth_sig not allowed: no post-quantum scheme is activated";
+        throw new P2pException(TypeEnum.BAD_TRX, "tx " + item.getHash() + " " + info);
+      }
+
       for (PQAuthSig pqAuthSig : trx.getPqAuthSigList()) {
         if (!PQAuthSigValidator.isLengthWithinBounds(pqAuthSig)) {
           throw new P2pException(TypeEnum.BAD_TRX,

--- a/framework/src/test/java/org/tron/common/crypto/pqc/PQAuthSigValidatorTest.java
+++ b/framework/src/test/java/org/tron/common/crypto/pqc/PQAuthSigValidatorTest.java
@@ -38,6 +38,14 @@ public class PQAuthSigValidatorTest {
   }
 
   @Test
+  public void rejectsUndersizedPublicKeyForRegisteredScheme() {
+    // Public key length must match the scheme exactly; a shorter key is rejected.
+    int pk = PQSchemeRegistry.getPublicKeyLength(PQScheme.FN_DSA_512) - 1;
+    int s = PQSchemeRegistry.getSignatureLength(PQScheme.FN_DSA_512);
+    assertFalse(PQAuthSigValidator.isLengthWithinBounds(sig(PQScheme.FN_DSA_512, pk, s)));
+  }
+
+  @Test
   public void rejectsOversizedSignatureForRegisteredScheme() {
     int pk = PQSchemeRegistry.getPublicKeyLength(PQScheme.ML_DSA_44);
     int s = PQSchemeRegistry.getSignatureLength(PQScheme.ML_DSA_44) + 1;

--- a/framework/src/test/java/org/tron/common/utils/LocalWitnessesTest.java
+++ b/framework/src/test/java/org/tron/common/utils/LocalWitnessesTest.java
@@ -60,8 +60,8 @@ public class LocalWitnessesTest {
             new PqKeypair(PQScheme.FN_DSA_512, shortPriv, pub))));
     assertEquals(TronError.ErrCode.WITNESS_INIT, err.getErrCode());
     assertTrue(err.getMessage().contains("PQ private key"));
-    // FN-DSA-512 private key is 1280 bytes = 2560 hex chars.
-    assertTrue(err.getMessage().contains("2560"));
+    // FN-DSA-512 private key is 1280 bytes; validation reports the byte length.
+    assertTrue(err.getMessage().contains("1280"));
   }
 
   @Test
@@ -73,8 +73,34 @@ public class LocalWitnessesTest {
             new PqKeypair(PQScheme.FN_DSA_512, priv, shortPub))));
     assertEquals(TronError.ErrCode.WITNESS_INIT, err.getErrCode());
     assertTrue(err.getMessage().contains("PQ public key"));
-    // FN-DSA-512 public key is 896 bytes = 1792 hex chars.
-    assertTrue(err.getMessage().contains("1792"));
+    // FN-DSA-512 public key is 896 bytes; validation reports the byte length.
+    assertTrue(err.getMessage().contains("896"));
+  }
+
+  @Test
+  public void oddLengthPrivateKeyRejectedAsLengthError() {
+    LocalWitnesses lw = new LocalWitnesses();
+    // Drop a single nibble -> odd hex length. fromHexString would left-pad this
+    // to the right byte count, so without an explicit length check it would slip
+    // through and fail later as a keypair mismatch. It must fail here instead.
+    String oddPriv = priv.substring(1);
+    TronError err = assertThrows(TronError.class,
+        () -> lw.setPqKeypairs(Collections.singletonList(
+            new PqKeypair(PQScheme.FN_DSA_512, oddPriv, pub))));
+    assertEquals(TronError.ErrCode.WITNESS_INIT, err.getErrCode());
+    assertTrue(err.getMessage().contains("PQ private key"));
+    assertTrue(err.getMessage().contains("1280"));
+  }
+
+  @Test
+  public void nullPrivateKeyRejected() {
+    LocalWitnesses lw = new LocalWitnesses();
+    TronError err = assertThrows(TronError.class,
+        () -> lw.setPqKeypairs(Collections.singletonList(
+            new PqKeypair(PQScheme.FN_DSA_512, null, pub))));
+    assertEquals(TronError.ErrCode.WITNESS_INIT, err.getErrCode());
+    assertTrue(err.getMessage().contains("PQ private key"));
+    assertTrue(err.getMessage().contains("1280"));
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -232,7 +232,9 @@ public class WalletMockTest {
     field.set(wallet, tronNetDelegateMock);
 
     // Single PQ signatures should reach the PQ size gate.
-    injectTotalSignNum(wallet, 5);
+    // A PQ scheme must be active, otherwise pq_auth_sig is rejected up front.
+    DynamicPropertiesStore dps = injectTotalSignNum(wallet, 5);
+    when(dps.isAnyPqSchemeAllowed()).thenReturn(true);
 
     int pk = PQSchemeRegistry.getPublicKeyLength(Protocol.PQScheme.FN_DSA_512);
     int sig = PQSchemeRegistry.getSignatureLength(Protocol.PQScheme.FN_DSA_512);
@@ -270,7 +272,8 @@ public class WalletMockTest {
   }
 
   /** Inject the signature-count cap used by broadcastTransaction. */
-  private static void injectTotalSignNum(Wallet wallet, int totalSignNum) throws Exception {
+  private static DynamicPropertiesStore injectTotalSignNum(Wallet wallet, int totalSignNum)
+      throws Exception {
     ChainBaseManager chainBaseManagerMock = mock(ChainBaseManager.class);
     DynamicPropertiesStore dynamicPropertiesStoreMock = mock(DynamicPropertiesStore.class);
     when(chainBaseManagerMock.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStoreMock);
@@ -278,6 +281,7 @@ public class WalletMockTest {
     Field field = wallet.getClass().getDeclaredField("chainBaseManager");
     field.setAccessible(true);
     field.set(wallet, chainBaseManagerMock);
+    return dynamicPropertiesStoreMock;
   }
 
   @Test
@@ -297,6 +301,38 @@ public class WalletMockTest {
     GrpcAPI.Return ret = wallet.broadcastTransaction(builder.build());
     assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
     assertTrue(ret.getMessage().toStringUtf8().contains("total signature count"));
+
+    // rejected up front: tronNetDelegate must not be consulted
+    Mockito.verify(tronNetDelegateMock, Mockito.never()).isBlockUnsolidified();
+  }
+
+  @Test
+  public void testBroadcastTxPqAuthSigSchemeNotActivated() throws Exception {
+    Wallet wallet = new Wallet();
+    TronNetDelegate tronNetDelegateMock = mock(TronNetDelegate.class);
+    Field field = wallet.getClass().getDeclaredField("tronNetDelegate");
+    field.setAccessible(true);
+    field.set(wallet, tronNetDelegateMock);
+
+    // No post-quantum scheme is activated.
+    DynamicPropertiesStore dps = injectTotalSignNum(wallet, 5);
+    when(dps.isAnyPqSchemeAllowed()).thenReturn(false);
+
+    // A well-formed pq_auth_sig must still be rejected solely because no scheme is active.
+    int pk = PQSchemeRegistry.getPublicKeyLength(Protocol.PQScheme.FN_DSA_512);
+    int sig = PQSchemeRegistry.getSignatureLength(Protocol.PQScheme.FN_DSA_512);
+    Protocol.Transaction tx = Protocol.Transaction.newBuilder()
+        .addPqAuthSig(Protocol.PQAuthSig.newBuilder()
+            .setScheme(Protocol.PQScheme.FN_DSA_512)
+            .setPublicKey(ByteString.copyFrom(new byte[pk]))
+            .setSignature(ByteString.copyFrom(new byte[sig]))
+            .build())
+        .build();
+
+    GrpcAPI.Return ret = wallet.broadcastTransaction(tx);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+    assertTrue(ret.getMessage().toStringUtf8()
+        .contains("pq_auth_sig not allowed: no post-quantum scheme is activated"));
 
     // rejected up front: tronNetDelegate must not be consulted
     Mockito.verify(tronNetDelegateMock, Mockito.never()).isBlockUnsolidified();

--- a/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
@@ -120,6 +120,8 @@ public class TransactionCapsuleTest extends BaseTest {
           rendered.contains(cap.getTransactionId().toString()));
       Assert.assertTrue("WARN should include sigCount: " + rendered,
           rendered.contains("sigCount="));
+      Assert.assertTrue("WARN should include pqSigCount: " + rendered,
+          rendered.contains("pqSigCount="));
       Assert.assertTrue("WARN should include cost in ms: " + rendered,
           rendered.contains("cost="));
       Assert.assertTrue("WARN should render ms suffix: " + rendered,

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -67,6 +67,7 @@ import org.tron.core.capsule.AccountCapsule;
 import org.tron.core.capsule.AssetIssueCapsule;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.BytesCapsule;
+import org.tron.core.capsule.ReceiptCapsule;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.capsule.TransactionInfoCapsule;
 import org.tron.core.capsule.TransactionRetCapsule;
@@ -972,6 +973,56 @@ public class ManagerTest extends BaseMethodTest {
     Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, a, diffEcdsa));
     // Same ECDSA but differing pq_auth_sig count (1 vs 0) -> not same.
     Assert.assertFalse((Boolean) isSameSig.invoke(dbManager, a, noPq));
+  }
+
+  private TransactionCapsule buildPqMultiSignTx(byte[] owner, int pqSigCount) {
+    TransferContract c = TransferContract.newBuilder()
+        .setOwnerAddress(ByteString.copyFrom(owner)).setAmount(1).build();
+    Transaction.Builder b = new TransactionCapsule(c, ContractType.TransferContract)
+        .getInstance().toBuilder();
+    for (int i = 0; i < pqSigCount; i++) {
+      b.addPqAuthSig(PQAuthSig.newBuilder().setScheme(PQScheme.FN_DSA_512)
+          .setSignature(ByteString.copyFrom(("pq-" + i).getBytes())).build());
+    }
+    return new TransactionCapsule(b.build());
+  }
+
+  @Test
+  public void consumeMultiSignFeeChargesPqOnlyMultiSign() throws Exception {
+    // A PQ-only multi-sign tx (0 ECDSA, 2 pq_auth_sig) must pay the multi-sign fee.
+    // The old gate getSignatureCount() > 1 saw 0 here and charged nothing; the fix
+    // counts both channels via getTotalSignatureCount().
+    byte[] owner = ByteArray.fromHexString("41abd4b9367799eaa3197fecb144eb71de1e049abc");
+    long fee = dbManager.getDynamicPropertiesStore().getMultiSignFee();
+    long initBalance = fee * 10;
+    AccountCapsule acc = new AccountCapsule(Account.newBuilder()
+        .setAddress(ByteString.copyFrom(owner)).setBalance(initBalance).build());
+    dbManager.getAccountStore().put(owner, acc);
+
+    TransactionTrace trace = mock(TransactionTrace.class);
+    when(trace.getReceipt()).thenReturn(mock(ReceiptCapsule.class));
+
+    dbManager.consumeMultiSignFee(buildPqMultiSignTx(owner, 2), trace);
+
+    Assert.assertEquals(initBalance - fee, dbManager.getAccountStore().get(owner).getBalance());
+  }
+
+  @Test
+  public void consumeMultiSignFeeSkipsSinglePqSig() throws Exception {
+    // One signature (1 pq_auth_sig) is not multi-sign -> no fee charged.
+    byte[] owner = ByteArray.fromHexString("41abd4b9367799eaa3197fecb144eb71de1e049abd");
+    long fee = dbManager.getDynamicPropertiesStore().getMultiSignFee();
+    long initBalance = fee * 10;
+    AccountCapsule acc = new AccountCapsule(Account.newBuilder()
+        .setAddress(ByteString.copyFrom(owner)).setBalance(initBalance).build());
+    dbManager.getAccountStore().put(owner, acc);
+
+    TransactionTrace trace = mock(TransactionTrace.class);
+    when(trace.getReceipt()).thenReturn(mock(ReceiptCapsule.class));
+
+    dbManager.consumeMultiSignFee(buildPqMultiSignTx(owner, 1), trace);
+
+    Assert.assertEquals(initBalance, dbManager.getAccountStore().get(owner).getBalance());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -438,6 +438,9 @@ public class TransactionsMsgHandlerTest extends BaseTest {
     TransactionsMsgHandler handler = new TransactionsMsgHandler();
     handler.init();
     injectChainBaseManager(handler);
+    // Activate a PQ scheme so the not-allowed gate passes and the size checks run.
+    long prevAllow = chainBaseManager.getDynamicPropertiesStore().getAllowFnDsa512();
+    chainBaseManager.getDynamicPropertiesStore().saveAllowFnDsa512(1L);
     try {
       PeerConnection peer = Mockito.mock(PeerConnection.class);
 
@@ -502,6 +505,7 @@ public class TransactionsMsgHandlerTest extends BaseTest {
       Assert.assertEquals(TypeEnum.BAD_TRX, ex2.getType());
       Assert.assertTrue(ex2.getMessage().contains("pq_auth_sig size is out of bounds"));
     } finally {
+      chainBaseManager.getDynamicPropertiesStore().saveAllowFnDsa512(prevAllow);
       handler.close();
     }
   }


### PR DESCRIPTION
**What does this PR do?**

Hardens post-quantum (`pq_auth_sig`) admission and unifies ECDSA/PQ signature counting, plus tightens PQ size and witness-key validation. Rebased on the latest `release_post_quantum`.


**Changes**
- Reject `pq_auth_sig` at RPC (`Wallet.broadcastTransaction`) and P2P (`TransactionsMsgHandler`) ingress when no PQ scheme is active — fast-fail mirroring the existing consensus guard.
- Count both channels via `getTotalSignatureCount()` for the total-sig cap and sign-weight paths.
- `PQAuthSigValidator`: public-key length must match exactly (`==`); signature checked against the scheme's valid band.
- `LocalWitnesses.validatePqKey`: decode via `ByteArray.fromHexString` (same decoder as the signing path), null-safe up-front length check, `expectedByteLen` naming.
- Narrow static `TransactionCapsule.validateSignature` to `private`; clarify `PQSchemeRegistry` length-unit docs.

Scope — does **not** change protobuf/wire format, add config, or alter consensus rules; the behavior change is limited to *earlier, consistent* rejection of already-invalid PQ transactions.

**Why are these changes required?**

- **Late rejection of disallowed PQ txs**: `pq_auth_sig` was only rejected at the consensus layer when no PQ scheme is active, so such txs still propagated through RPC broadcast and P2P ingress before being dropped.
- **Asymmetric signature checks**: several count/length checks looked at only one channel (ECDSA *or* PQ), making the total-signature cap, multi-sign fee, and sign-weight inconsistent across the two.
- **Weak witness-key diagnostics**: a wrong/odd-length PQ key in node config surfaced late as a misleading "keypair mismatch".

**This PR has been tested by:**
- Unit Tests — `WalletMockTest`, `TransactionsMsgHandlerTest`, `LocalWitnessesTest`, `PQAuthSigValidatorTest`, `TransactionCapsuleTest`, `ManagerTest`: all pass; `compileJava`/`compileTestJava` clean.
- Manual Testing — n/a
