### PR TITLE
refactor(chainbase): simplify post-quantum code

### DIFF
--- a/chainbase/src/main/java/org/tron/core/db/BandwidthProcessor.java
+++ b/chainbase/src/main/java/org/tron/core/db/BandwidthProcessor.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Commons;
 import org.tron.common.utils.StringUtil;
@@ -147,7 +148,7 @@ public class BandwidthProcessor extends ResourceProcessor {
           if (trx.getInstance().getPqAuthSigCount() > 0) {
             long pqAuthSigBytes = 0L;
             for (PQAuthSig pqAuthSig : trx.getInstance().getPqAuthSigList()) {
-              pqAuthSigBytes += pqAuthSig.getSerializedSize();
+              pqAuthSigBytes += PQSchemeRegistry.computePQAuthSigWireSize(pqAuthSig.getScheme());
             }
             sigOverhead += pqAuthSigBytes;
           }

--- a/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
@@ -3127,12 +3127,8 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
    * needed.
    */
   public boolean isAnyPqSchemeAllowed() {
-    for (PQScheme scheme : PQSchemeRegistry.registeredSchemes()) {
-      if (isPqSchemeAllowed(scheme)) {
-        return true;
-      }
-    }
-    return false;
+    return PQSchemeRegistry.registeredSchemes().stream()
+        .anyMatch(this::isPqSchemeAllowed);
   }
 
   /**
@@ -3147,10 +3143,6 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
       case FN_DSA_512: return allowFnDsa512();
       case ML_DSA_44: return allowMlDsa44();
       default:
-        if (PQSchemeRegistry.contains(scheme)) {
-          throw new IllegalStateException(
-              "Missing governance flag mapping for registered PQ scheme: " + scheme);
-        }
         return false;
     }
   }

--- a/consensus/src/main/java/org/tron/consensus/base/Param.java
+++ b/consensus/src/main/java/org/tron/consensus/base/Param.java
@@ -122,8 +122,9 @@ public class Param {
 
     /**
      * Post-quantum identity bundle: scheme + key material + derived addresses.
-     * Immutable; key bytes are defensively copied on the way in and out so the
-     * stored material can't be mutated by callers.
+     * Fields are {@code final}; the key {@code byte[]} references are held
+     * directly (not copied), so callers must not mutate the arrays they pass in
+     * or get back.
      */
     public class PQMiner {
 

--- a/consensus/src/main/java/org/tron/consensus/base/Param.java
+++ b/consensus/src/main/java/org/tron/consensus/base/Param.java
@@ -74,13 +74,12 @@ public class Param {
      * set so the two miner kinds never share a slot.
      */
     @Getter
-    private final PQMiner pq;
+    private PQMiner pq;
 
     public Miner(byte[] privateKey, ByteString privateKeyAddress, ByteString witnessAddress) {
       this.privateKey = privateKey;
       this.privateKeyAddress = privateKeyAddress;
       this.witnessAddress = witnessAddress;
-      this.pq = null;
     }
 
     /**
@@ -131,8 +130,10 @@ public class Param {
       @Getter
       private final PQScheme scheme;
 
+      @Getter
       private final byte[] privateKey;
 
+      @Getter
       private final byte[] publicKey;
 
       /** Address derived from the PQ public key (key-slot identity). */
@@ -151,14 +152,6 @@ public class Param {
         this.publicKey = publicKey == null ? null : publicKey.clone();
         this.privateKeyAddress = privateKeyAddress;
         this.witnessAddress = witnessAddress;
-      }
-
-      public byte[] getPrivateKey() {
-        return privateKey == null ? null : privateKey.clone();
-      }
-
-      public byte[] getPublicKey() {
-        return publicKey == null ? null : publicKey.clone();
       }
     }
   }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -99,7 +99,7 @@ public class TransactionsMsgHandler implements TronMsgHandler {
       Item item = new Item(new TransactionMessage(trx).getMessageId(), InventoryType.TRX);
       // Observe end-to-end fetch latency (GET_DATA send → full TXS received)
       // before consuming the timestamp. Null means this tx wasn't actively
-      // fetched (e.g. pushed via gossip), in which case no sample is recorded.
+      // fetched, in which case no sample is recorded.
       Long requestTime = peer.getAdvInvRequest().remove(item);
       if (requestTime != null) {
         Metrics.histogramObserve(MetricKeys.Histogram.TX_FETCH_LATENCY,

--- a/framework/src/test/java/org/tron/core/consensus/ParamPqMinerTest.java
+++ b/framework/src/test/java/org/tron/core/consensus/ParamPqMinerTest.java
@@ -80,27 +80,6 @@ public class ParamPqMinerTest {
   }
 
   @Test
-  public void pqMinerCopiesKeyBytesOnTheWayInAndOut() {
-    byte[] priv = {1, 2, 3, 4};
-    byte[] pub = {5, 6, 7, 8};
-    Miner miner = newPqMiner(priv, pub);
-
-    // Mutating the source arrays must not affect the stored material.
-    priv[0] = 99;
-    pub[0] = 99;
-    assertEquals(1, miner.getPq().getPrivateKey()[0]);
-    assertEquals(5, miner.getPq().getPublicKey()[0]);
-
-    // Each getter hands back a fresh copy, not the backing array.
-    byte[] out1 = miner.getPq().getPrivateKey();
-    byte[] out2 = miner.getPq().getPrivateKey();
-    assertNotSame(out1, out2);
-    assertArrayEquals(out1, out2);
-    out1[0] = 42;
-    assertEquals(1, miner.getPq().getPrivateKey()[0]);
-  }
-
-  @Test
   public void pqMinerToleratesNullKeyMaterial() {
     Miner miner = newPqMiner(null, null);
     assertNull(miner.getPq().getPrivateKey());

--- a/plugins/src/main/java/common/org/tron/plugins/PqKeyNew.java
+++ b/plugins/src/main/java/common/org/tron/plugins/PqKeyNew.java
@@ -114,9 +114,10 @@ public class PqKeyNew implements Callable<Integer> {
         out.println("- privateKey takes priority at load time; seed is retained as a backup.");
         if (pqScheme == PQScheme.FN_DSA_512) {
           out.println();
-          out.println("NOTE (FN_DSA_512): The seed in this file is for reference only."
+          out.println(spec.commandLine().getColorScheme().ansi().string(
+              "@|red NOTE (FN_DSA_512): The seed in this file is for reference only."
               + " Falcon keygen is NOT bit-stable across JVM versions, so the stored"
-              + " privateKey + publicKey are always used.");
+              + " privateKey + publicKey are always used.|@"));
         }
       }
       return 0;


### PR DESCRIPTION
**What does this PR do?**

A set of small post-quantum-related cleanups and one resource-accounting consistency fix:

- **`BandwidthProcessor`** — when consuming bandwidth for a tx's `pq_auth_sig` entries, charge `PQSchemeRegistry.computePQAuthSigWireSize(scheme)` instead of `pqAuthSig.getSerializedSize()`. This aligns the *charging* path with the *estimation* path (`Manager.getCanDelegatedMaxSize`, `TransactionUtil`), which already uses the same per-scheme wire-size helper. The computed value is the scheme upper bound plus field framing, so it is always ≥ the actual serialized size (no undercharge).
- **`DynamicPropertiesStore`** — rewrite `isAnyPqSchemeAllowed()` as a stream `anyMatch` (behavior-preserving), and drop the `IllegalStateException` in `isPqSchemeAllowed`'s `default` branch so an unmapped scheme simply resolves to "not allowed".
- **`Param.PQMiner`** — replace the manual defensive-copy getters with Lombok `@Getter` and store key bytes directly; drop `final`/explicit `null` init on the `pq` field. The class javadoc is updated to state the real contract (fields are `final`, key `byte[]` references are held directly and must not be mutated by callers), and the now-obsolete `pqMinerCopiesKeyBytesOnTheWayInAndOut` test is removed.
- **`PqKeyNew` (Toolkit)** — color the `FN_DSA_512` seed NOTE red via picocli's color scheme (TTY-aware; stripped on redirect/`NO_COLOR`).
- **`TransactionsMsgHandler`** — minor comment trim.

**Why are these changes required?**

To keep PQ bandwidth accounting consistent between estimation and actual consumption (the previous mismatch could make `getCanDelegatedMaxSize` disagree with what `consume` charged), and to simplify PQ-related code that had grown more defensive than needed before activation.

**This PR has been tested by:**
- Unit Tests
- Manual Testing — `Toolkit.jar pq-key new --scheme=FN_DSA_512` shows the colored NOTE.

**Follow up**

- None.

**Extra details**

- The `BandwidthProcessor` change is consensus-relevant (it changes resource consumption), so it must land **before** PQ proposals activate on Nile — which it does, since base is `release_post_quantum` (pre-activation).
- `Param.PQMiner` no longer defensively copies private-key bytes (getters return the internal reference); this is an intentional simplification for pre-activation code, and the javadoc now reflects it.
