### PR TITLE
fix(test): align market proposal test with nile

### DIFF
--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -339,7 +339,7 @@ public class ProposalUtilTest extends BaseTest {
 
     testAllowTvmBlobProposal();
 
-    testAllowMarketTransaction();
+    //testAllowMarketTransaction();
 
     testAllowTvmSelfdestructRestrictionProposal();
 

--- a/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/ProposalUtilTest.java
@@ -339,7 +339,7 @@ public class ProposalUtilTest extends BaseTest {
 
     testAllowTvmBlobProposal();
 
-    //testAllowMarketTransaction();
+    testAllowMarketTransaction();
 
     testAllowTvmSelfdestructRestrictionProposal();
 
@@ -768,11 +768,12 @@ public class ProposalUtilTest extends BaseTest {
 
     activateFork(ForkBlockVersionEnum.VERSION_4_8_1);
 
-    thrown = assertThrows(ContractValidateException.class, open);
-    assertEquals(err, thrown.getMessage());
+    // TODO: ProposalUtil.ALLOW_MARKET_TRANSACTION does not reject proposals after VERSION_4_8_1
+    // thrown = assertThrows(ContractValidateException.class, open);
+    // assertEquals(err, thrown.getMessage());
 
-    thrown = assertThrows(ContractValidateException.class, off);
-    assertEquals(err, thrown.getMessage());
+    // thrown = assertThrows(ContractValidateException.class, off);
+    // assertEquals(err, thrown.getMessage());
   }
 
   private void activateFork(ForkBlockVersionEnum forkVersion) {


### PR DESCRIPTION
**What does this PR do?**

- Comments out the two upstream assertions in `testAllowMarketTransaction()` that expect `ALLOW_MARKET_TRANSACTION` proposals to be rejected after `VERSION_4_8_1`.
- Keeps `testAllowMarketTransaction()` enabled, including the checks before `VERSION_4_8_1`.
- Keeps the rest of `ProposalUtil` validation coverage unchanged.

**Why are these changes required?**

`upstream/release_v4.8.2` treats `ALLOW_MARKET_TRANSACTION` as a one-way proposal: it can be enabled before `VERSION_4_8_1`, cannot be disabled, and becomes an invalid proposal id after `VERSION_4_8_1`. The upstream test therefore asserts that both `ALLOW_MARKET_TRANSACTION = 1` and `ALLOW_MARKET_TRANSACTION = 0` throw `Bad chain parameter id [ALLOW_MARKET_TRANSACTION]` after `VERSION_4_8_1`.

The Nile `release_v4.8.2_build2` branch intentionally diverges from that behavior to support disabling market transactions. In this branch, `ProposalUtil` does not reject `ALLOW_MARKET_TRANSACTION` proposals after `VERSION_4_8_1` in the same way as upstream, so those two upstream-only assertions no longer match the branch behavior.

This PR narrows the test adjustment to only the incompatible post-`VERSION_4_8_1` assertions, instead of disabling the whole market transaction proposal test.

**This PR has been tested by:**

- Unit Tests

**Follow up**

- Consider replacing the commented assertions with Nile-specific assertions that explicitly verify the intended post-`VERSION_4_8_1` behavior for `ALLOW_MARKET_TRANSACTION = 0` and `ALLOW_MARKET_TRANSACTION = 1`.

**Extra details**

- Related failing test: `org.tron.core.actuator.utils.ProposalUtilTest.validateCheck`
- Root difference: Nile `release_v4.8.2_build2` market transaction governance differs from upstream `release_v4.8.2`.